### PR TITLE
Add describe pvc command to the openebsctl

### DIFF
--- a/client/k8s.go
+++ b/client/k8s.go
@@ -280,6 +280,8 @@ func (k K8sClient) GetPVCs(namespace string, pvcNames []string) (*corev1.Persist
 	}, nil
 }
 
+// GetCasType from the v1pv and v1sc, this is a fallback checker method, it checks
+// both the resource only if the castype is not found.
 func GetCasType(v1PV *corev1.PersistentVolume, v1SC *v1.StorageClass) string {
 	if val := GetCasTypeFromPV(v1PV); val != util.UNKNOWN {
 		return val
@@ -356,7 +358,7 @@ func (k K8sClient) GetCstorVolumeTargetPod(volumeName string) (*corev1.Pod, erro
 	return nil, errors.New("The target pod for the given cstor volume was not found")
 }
 
-// GetReadyContainers to show the number of ready bs total containers of pod
+// GetReadyContainers to show the number of ready vs total containers of pod i.e 2/3
 func GetReadyContainers(containers []corev1.ContainerStatus) string {
 	total := len(containers)
 	ready := 0

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -283,41 +283,41 @@ func (k K8sClient) GetPVCs(namespace string, pvcNames []string) (*corev1.Persist
 // GetCasType from the v1pv and v1sc, this is a fallback checker method, it checks
 // both the resource only if the castype is not found.
 func GetCasType(v1PV *corev1.PersistentVolume, v1SC *v1.StorageClass) string {
-	if val := GetCasTypeFromPV(v1PV); val != util.UNKNOWN {
+	if val := GetCasTypeFromPV(v1PV); val != util.Unknown {
 		return val
 	}
-	if val := GetCasTypeFromSC(v1SC); val != util.UNKNOWN {
+	if val := GetCasTypeFromSC(v1SC); val != util.Unknown {
 		return val
 	}
-	return util.UNKNOWN
+	return util.Unknown
 }
 
 // GetCasTypeFromPV from the passed PersistentVolume or the Stora
 func GetCasTypeFromPV(v1PV *corev1.PersistentVolume) string {
 	if v1PV.ObjectMeta.Labels != nil {
-		if _, ok := v1PV.ObjectMeta.Labels[util.OPENEBS_CAS_TYPE_KEY]; ok {
-			return v1PV.ObjectMeta.Labels[util.OPENEBS_CAS_TYPE_KEY]
+		if _, ok := v1PV.ObjectMeta.Labels[util.OpenEBSCasTypeKey]; ok {
+			return v1PV.ObjectMeta.Labels[util.OpenEBSCasTypeKey]
 		}
 	} else if v1PV.ObjectMeta.Annotations != nil {
-		if _, ok := v1PV.ObjectMeta.Annotations[util.OPENEBS_CAS_TYPE_KEY]; ok {
-			return v1PV.ObjectMeta.Annotations[util.OPENEBS_CAS_TYPE_KEY]
+		if _, ok := v1PV.ObjectMeta.Annotations[util.OpenEBSCasTypeKey]; ok {
+			return v1PV.ObjectMeta.Annotations[util.OpenEBSCasTypeKey]
 		}
 	} else if v1PV.Spec.CSI != nil && v1PV.Spec.CSI.VolumeAttributes != nil {
-		if _, ok := v1PV.Spec.CSI.VolumeAttributes[util.OPENEBS_CAS_TYPE_KEY]; ok {
-			return v1PV.Spec.CSI.VolumeAttributes[util.OPENEBS_CAS_TYPE_KEY]
+		if _, ok := v1PV.Spec.CSI.VolumeAttributes[util.OpenEBSCasTypeKey]; ok {
+			return v1PV.Spec.CSI.VolumeAttributes[util.OpenEBSCasTypeKey]
 		}
 	}
-	return util.UNKNOWN
+	return util.Unknown
 }
 
 // GetCasTypeFromSC by passing the storage class
 func GetCasTypeFromSC(v1SC *v1.StorageClass) string {
 	if v1SC.Parameters != nil {
-		if _, ok := v1SC.Parameters[util.OPENBEBS_CAS_TYPE_KEY_SC]; ok {
-			return v1SC.Parameters[util.OPENBEBS_CAS_TYPE_KEY_SC]
+		if _, ok := v1SC.Parameters[util.OpenEBSCasTypeKeySc]; ok {
+			return v1SC.Parameters[util.OpenEBSCasTypeKeySc]
 		}
 	}
-	return util.UNKNOWN
+	return util.Unknown
 }
 
 // GetCVA from the passed cstorvolume name

--- a/kubectl-openebs/cli/command/describe/describe.go
+++ b/kubectl-openebs/cli/command/describe/describe.go
@@ -24,10 +24,14 @@ import (
 
 const (
 	volumeCommandHelpText = `# Show detail of a specific OpenEBS resource:
-$ kubectl openebs describe [volumes|pools] [name]
+$ kubectl openebs describe [volumes|pools|pvc] [name]
 
 # Describe a Volume:
 $ kubectl openebs describe volume pvc-abcd -n [namespace]
+
+# Describe PVCs present in the same namespace:
+$ kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]
+
 `
 )
 

--- a/kubectl-openebs/cli/command/describe/describe.go
+++ b/kubectl-openebs/cli/command/describe/describe.go
@@ -44,6 +44,7 @@ func NewCmdDescribe(rootCmd *cobra.Command) *cobra.Command {
 
 	cmd.AddCommand(
 		NewCmdDescribeVolume(),
+		NewCmdDescribePVC(),
 		// TODO: Add NewCmdPoolInfo()
 	)
 

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -189,7 +189,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 
 				// fetching the underlying TargetPod for the PV, to display its relevant details and notify the user
 				// if the TargetPod is not found.
-				targetPod, err := clientset.GetCstorVolumeTargetPod(item.Spec.VolumeName)
+				targetPod, err := clientset.GetCstorVolumeTargetPod(item.Name, item.Spec.VolumeName)
 				if err == nil {
 					targetPodOutput := make([]string, 2)
 					fmt.Printf("Target Details :\n")

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -29,11 +29,11 @@ import (
 
 var (
 	pvcInfoCommandHelpText = `
-This command fetches information and status of the various
-aspects of a PersistentVolumeClaim and its underlying related
-resources.
+This command fetches information and status  of  the  various  aspects 
+of  the  PersistentVolumeClaims  and  its underlying related resources 
+in the provided namespace. If no namespace is provided it uses default
+namespace for execution.
 
-#
 $ kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]
 
 `
@@ -84,7 +84,7 @@ func NewCmdDescribePVC() *cobra.Command {
 		Aliases: []string{"pvcs", "persistentvolumeclaims", "persistentvolumeclaim"},
 		Short:   "Displays PersistentVolumeClaim information",
 		Long:    pvcInfoCommandHelpText,
-		Example: `kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]`,
+		Example: `kubectl openebs describe pvc cstor-vol-1 cstor-vol-2 -n storage`,
 		Run: func(cmd *cobra.Command, args []string) {
 			var ns string // This namespace belongs to the PVC entered
 			if ns, _ = cmd.Flags().GetString("namespace"); ns == "" {
@@ -97,6 +97,9 @@ func NewCmdDescribePVC() *cobra.Command {
 }
 
 func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
+	if len(pvcs) == 0 {
+		return errors.New("Please give at least one pvc name to describe")
+	}
 	// TODO: Make K8sClient to be able to determine openebs namespace by itself.
 	// Below is currently hardcoded to support only if resources are in openebs ns
 	// because the -n flag is used to take the pvc namespace and same cannot be used to
@@ -251,6 +254,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 					return err
 				}
 			}
+			// A separator to separate multiple pvc describes
 			if len(pvcList.Items) > 1 && ind != len(pvcList.Items)-1 {
 				fmt.Println("-------------------------------------------------------------------------------------")
 			}

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package describe
+
+import (
+	"fmt"
+	"html/template"
+	"os"
+	"time"
+
+	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
+	"github.com/openebs/openebsctl/client"
+	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pvcInfoCommandHelpText = `
+This command fetches information and status of the various
+aspects of a PersistentVolumeClaim and its underlying related
+resources.
+
+#
+$ kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]
+
+`
+)
+
+const (
+	cstorPvcInfoTemplate = `
+{{.Name}} Details :
+-------------------
+Name             : {{.Name}}
+Namespace        : {{.Namespace}}
+Cas Type         : {{.CasType}}
+Bound Volume     : {{.BoundVolume}}
+Attached To Node : {{.AttachedToNode}}
+Pool             : {{.Pool}}
+Storage Class    : {{.StorageClassName}}
+Size             : {{.Size}}
+Used             : {{.Used}}
+PV Status	 : {{.PVStatus}}
+
+`
+
+	detailsFromCVC = `
+Additional Details from CVC :
+-----------------------------
+Name          : {{.Name}}
+Replica Count : {{.ReplicaCount}}
+Pool Info     : {{.PoolInfo}}
+Version       : {{.Version}}
+Upgrading     : {{.Upgrading}}
+
+`
+
+	genericPvcInfoTemplate = `
+{{.Name}} Details :
+-------------------
+Name             : {{.Name}}
+Namespace        : {{.Namespace}}
+Cas Type         : {{.CasType}}
+Bound Volume     : {{.BoundVolume}}
+Storage Class    : {{.StorageClassName}}
+Size             : {{.Size}}
+PV Status	 : {{.PVStatus}}
+
+`
+)
+
+func NewCmdDescribePVC() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "pvc",
+		Aliases: []string{"pvcs", "persistentvolumeclaims", "persistentvolumeclaim"},
+		Short:   "Displays Openebs information",
+		Long:    volumeInfoCommandHelpText,
+		Example: `kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var ns string
+			if ns, _ = cmd.Flags().GetString("namespace"); ns == "" {
+				// NOTE: The error comes as nil even when the ns flag is not specified
+				ns = "default"
+			}
+			util.CheckErr(RunPVCInfo(cmd, args, ns), util.Fatal)
+		},
+	}
+	return cmd
+}
+
+func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
+	// TODO: Make K8sClient to be able to determine openebs namespace by itself.
+	// Please change the below with the namespace where openebs is installed in the cluster
+	clientset, err := client.NewK8sClient("openebs")
+	if err != nil {
+		return errors.Wrap(err, "failed to execute pvc info command")
+	}
+	pvcList, err := clientset.GetPVCs(ns, pvcs)
+	if err != nil {
+		return errors.Wrap(err, "failed to execute pvc info command")
+	}
+	for _, item := range pvcList.Items {
+		sc, err := clientset.GetStorageClass(*item.Spec.StorageClassName)
+		if err != nil {
+			fmt.Println("Error Fetching StorageClass details for", item.Name)
+			continue
+		}
+		casType := client.GetCasTypeFromSC(sc)
+		if casType == util.CSTOR_CAS_TYPE {
+			pvcInfo := util.CstorPVCInfo{}
+			cv, err := clientset.GetcStorVolume(item.Spec.VolumeName)
+			if err != nil {
+				fmt.Println("Error Fetching ctsor volume details for", item.Name)
+				continue
+			}
+
+			cvcInfo := util.CVCInfo{}
+			cvc, err := clientset.GetCVC(item.Spec.VolumeName)
+			if err != nil {
+				fmt.Println("Error Fetching cstor volume config details for", item.Name)
+				continue
+			}
+			cvcInfo.Name = cvc.Name
+			cvcInfo.ReplicaCount = len(cvc.Status.PoolInfo)
+			cvcInfo.PoolInfo = cvc.Status.PoolInfo
+			cvcInfo.Version = cvc.VersionDetails.Status.Current
+			cvcInfo.Upgrading = cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired
+
+			cva, err := clientset.GetCVA(item.Spec.VolumeName)
+			if err == nil {
+				pvcInfo.AttachedToNode = cva.Spec.Volume.OwnerNodeID
+			}
+			cvrs, err := clientset.GetCVR(item.Spec.VolumeName)
+			if err == nil && len(cvrs.Items) > 0 {
+				pvcInfo.Used = client.GetUsedCapacityFromCVR(cvrs)
+			}
+			pvcInfo.Name = item.Name
+			pvcInfo.Namespace = item.Namespace
+			pvcInfo.BoundVolume = item.Spec.VolumeName
+			pvcInfo.CasType = casType
+			pvcInfo.Pool = cvc.Labels[cstortypes.CStorPoolClusterLabelKey]
+			pvcInfo.AttachedToNode = cva.Spec.Volume.OwnerNodeID
+			pvcInfo.StorageClassName = *item.Spec.StorageClassName
+			pvcInfo.Size = cv.Spec.Capacity.String()
+			pvcInfo.PVStatus = cv.Status.Phase
+
+			pvcInfoTemplate, err := template.New("pvc").Parse(cstorPvcInfoTemplate)
+			if err != nil {
+				return errors.Wrap(err, "error displaying output for pvc info")
+			}
+			err = pvcInfoTemplate.Execute(os.Stdout, pvcInfo)
+			if err != nil {
+				return errors.Wrap(err, "error displaying cvc details")
+			}
+
+			targetPod, err := clientset.GetCstorVolumeTargetPod(item.Spec.VolumeName)
+			targetPodOutput := make([]string, 3)
+			if err == nil {
+				fmt.Printf("Target Details :\n----------------\n")
+				targetPodOutput[0] = "Namespace|Name|Ready|Status|Age|IP|Node"
+				targetPodOutput[1] = "---------|----|-----|------|---|--|----"
+				targetPodOutput[2] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
+					targetPod.Namespace,
+					targetPod.Name,
+					client.GetReadyContainers(targetPod.Status.ContainerStatuses),
+					targetPod.Status.Phase,
+					util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)),
+					targetPod.Status.PodIP,
+					targetPod.Spec.NodeName,
+				)
+			}
+			fmt.Println(util.FormatList(targetPodOutput))
+
+			if cvrs != nil {
+				fmt.Printf("\nReplica Details :\n----------------\n")
+				cvrOutput := make([]string, len(cvrs.Items)+2)
+				cvrOutput[0] = "Name|Total|Used|Status|Age"
+				cvrOutput[1] = "----|-----|----|------|---"
+				for i, cvr := range cvrs.Items {
+					cvrOutput[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s",
+						cvr.Name,
+						cvr.Status.Capacity.Total,
+						cvr.Status.Capacity.Used,
+						cvr.Status.Phase,
+						util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time)),
+					)
+				}
+				fmt.Println(util.FormatList(cvrOutput))
+			}
+
+			cvcInfoTemplate, err := template.New("cvc").Parse(detailsFromCVC)
+			if err != nil {
+				return errors.Wrap(err, "error displaying output for cvc info")
+			}
+			err = cvcInfoTemplate.Execute(os.Stdout, cvcInfo)
+			if err != nil {
+				return errors.Wrap(err, "error displaying cvc details")
+			}
+		} else {
+			pvcInfo := util.PVCInfo{}
+			pvcInfo.Name = item.Name
+			pvcInfo.Namespace = item.Namespace
+			pvcInfo.StorageClassName = *item.Spec.StorageClassName
+			quantity := item.Status.Capacity["storage"]
+			pvcInfo.Size = quantity.String()
+			pv, err := clientset.GetPV(item.Spec.VolumeName)
+			if err == nil {
+				pvcInfo.BoundVolume = item.Spec.VolumeName
+				pvcInfo.PVStatus = pv.Status.Phase
+				pvcInfo.CasType = client.GetCasType(pv, sc)
+			}
+			cvcInfoTemplate, err := template.New("pvc").Parse(genericPvcInfoTemplate)
+			if err != nil {
+				return errors.Wrap(err, "error displaying output for pvc info")
+			}
+			err = cvcInfoTemplate.Execute(os.Stdout, pvcInfo)
+			if err != nil {
+				return errors.Wrap(err, "error displaying pvc details")
+			}
+		}
+	}
+	return nil
+}

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -138,7 +138,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 			cvcInfo.ReplicaCount = len(cvc.Status.PoolInfo)
 			cvcInfo.PoolInfo = cvc.Status.PoolInfo
 			cvcInfo.Version = cvc.VersionDetails.Status.Current
-			cvcInfo.Upgrading = cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired
+			cvcInfo.Upgrading = !(cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired)
 
 			cva, err := clientset.GetCVA(item.Spec.VolumeName)
 			if err == nil {

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -78,6 +78,7 @@ PV Status	 : {{.PVStatus}}
 `
 )
 
+// NewCmdDescribePVC Displays the pvc describe details
 func NewCmdDescribePVC() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pvc",
@@ -96,6 +97,7 @@ func NewCmdDescribePVC() *cobra.Command {
 	return cmd
 }
 
+// RunPVCInfo runs info command and make call to display the results
 func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 	if len(pvcs) == 0 {
 		return errors.New("Please give at least one pvc name to describe")
@@ -127,7 +129,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 			// TODO: Adding support for other casTypes
 			// Get the casType from the storage class and branch on basic of CSTOR and NON-CSTOR PVCs.
 			casType := client.GetCasTypeFromSC(sc)
-			if casType == util.CSTOR_CAS_TYPE {
+			if casType == util.CstorCasType {
 
 				// Create Empty template objects and fill gradually when underlying sub CRs are identified.
 				pvcInfo := util.CstorPVCInfo{}
@@ -241,7 +243,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 				pvcInfo.Name = item.Name
 				pvcInfo.Namespace = item.Namespace
 				pvcInfo.StorageClassName = *item.Spec.StorageClassName
-				quantity := item.Status.Capacity[util.STORAGE]
+				quantity := item.Status.Capacity[util.StorageKey]
 				pvcInfo.Size = quantity.String()
 				pv, err := clientset.GetPV(item.Spec.VolumeName)
 				if err == nil {

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -18,8 +18,6 @@ package describe
 
 import (
 	"fmt"
-	"html/template"
-	"os"
 	"time"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
@@ -44,7 +42,6 @@ $ kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]
 const (
 	cstorPvcInfoTemplate = `
 {{.Name}} Details :
--------------------
 Name             : {{.Name}}
 Namespace        : {{.Namespace}}
 Cas Type         : {{.CasType}}
@@ -60,7 +57,6 @@ PV Status	 : {{.PVStatus}}
 
 	detailsFromCVC = `
 Additional Details from CVC :
------------------------------
 Name          : {{.Name}}
 Replica Count : {{.ReplicaCount}}
 Pool Info     : {{.PoolInfo}}
@@ -71,7 +67,6 @@ Upgrading     : {{.Upgrading}}
 
 	genericPvcInfoTemplate = `
 {{.Name}} Details :
--------------------
 Name             : {{.Name}}
 Namespace        : {{.Namespace}}
 Cas Type         : {{.CasType}}
@@ -87,13 +82,12 @@ func NewCmdDescribePVC() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pvc",
 		Aliases: []string{"pvcs", "persistentvolumeclaims", "persistentvolumeclaim"},
-		Short:   "Displays Openebs information",
-		Long:    volumeInfoCommandHelpText,
+		Short:   "Displays PersistentVolumeClaim information",
+		Long:    pvcInfoCommandHelpText,
 		Example: `kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var ns string
+			var ns string // This namespace belongs to the PVC entered
 			if ns, _ = cmd.Flags().GetString("namespace"); ns == "" {
-				// NOTE: The error comes as nil even when the ns flag is not specified
 				ns = "default"
 			}
 			util.CheckErr(RunPVCInfo(cmd, args, ns), util.Fatal)
@@ -104,134 +98,165 @@ func NewCmdDescribePVC() *cobra.Command {
 
 func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string) error {
 	// TODO: Make K8sClient to be able to determine openebs namespace by itself.
-	// Please change the below with the namespace where openebs is installed in the cluster
+	// Below is currently hardcoded to support only if resources are in openebs ns
+	// because the -n flag is used to take the pvc namespace and same cannot be used to
+	// take the openebs namespace
 	clientset, err := client.NewK8sClient("openebs")
 	if err != nil {
-		return errors.Wrap(err, "failed to execute pvc info command")
+		return errors.Wrap(err, "Failed to execute describe pvc command")
 	}
+	// Fetch the list of v1PVC objects by passing the name of PVCs taken through CLI in ns namespace
 	pvcList, err := clientset.GetPVCs(ns, pvcs)
+	// Incase the PVCs are not found no further operation to be performed
 	if err != nil {
-		return errors.Wrap(err, "failed to execute pvc info command")
+		return errors.Wrap(err, "Failed to execute describe pvc command")
 	}
-	for _, item := range pvcList.Items {
-		sc, err := clientset.GetStorageClass(*item.Spec.StorageClassName)
-		if err != nil {
-			fmt.Println("Error Fetching StorageClass details for", item.Name)
-			continue
-		}
-		casType := client.GetCasTypeFromSC(sc)
-		if casType == util.CSTOR_CAS_TYPE {
-			pvcInfo := util.CstorPVCInfo{}
-			cv, err := clientset.GetcStorVolume(item.Spec.VolumeName)
+	if pvcList != nil && len(pvcList.Items) > 0 {
+		// Loop over the PVCs that are valid and found in ns namespace and
+		// show their details.
+		for ind, item := range pvcList.Items {
+			// Get the storageClass object and skip the rest of the loop if not found.
+			sc, err := clientset.GetStorageClass(*item.Spec.StorageClassName)
 			if err != nil {
-				fmt.Println("Error Fetching ctsor volume details for", item.Name)
+				fmt.Println("Error Fetching StorageClass details for", item.Name)
 				continue
 			}
+			// TODO: Adding support for other casTypes
+			// Get the casType from the storage class and branch on basic of CSTOR and NON-CSTOR PVCs.
+			casType := client.GetCasTypeFromSC(sc)
+			if casType == util.CSTOR_CAS_TYPE {
 
-			cvcInfo := util.CVCInfo{}
-			cvc, err := clientset.GetCVC(item.Spec.VolumeName)
-			if err != nil {
-				fmt.Println("Error Fetching cstor volume config details for", item.Name)
-				continue
-			}
-			cvcInfo.Name = cvc.Name
-			cvcInfo.ReplicaCount = len(cvc.Status.PoolInfo)
-			cvcInfo.PoolInfo = cvc.Status.PoolInfo
-			cvcInfo.Version = cvc.VersionDetails.Status.Current
-			cvcInfo.Upgrading = !(cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired)
+				// Create Empty template objects and fill gradually when underlying sub CRs are identified.
+				pvcInfo := util.CstorPVCInfo{}
+				cvcInfo := util.CVCInfo{}
 
-			cva, err := clientset.GetCVA(item.Spec.VolumeName)
-			if err == nil {
-				pvcInfo.AttachedToNode = cva.Spec.Volume.OwnerNodeID
-			}
-			cvrs, err := clientset.GetCVR(item.Spec.VolumeName)
-			if err == nil && len(cvrs.Items) > 0 {
-				pvcInfo.Used = client.GetUsedCapacityFromCVR(cvrs)
-			}
-			pvcInfo.Name = item.Name
-			pvcInfo.Namespace = item.Namespace
-			pvcInfo.BoundVolume = item.Spec.VolumeName
-			pvcInfo.CasType = casType
-			pvcInfo.Pool = cvc.Labels[cstortypes.CStorPoolClusterLabelKey]
-			pvcInfo.AttachedToNode = cva.Spec.Volume.OwnerNodeID
-			pvcInfo.StorageClassName = *item.Spec.StorageClassName
-			pvcInfo.Size = cv.Spec.Capacity.String()
-			pvcInfo.PVStatus = cv.Status.Phase
-
-			pvcInfoTemplate, err := template.New("pvc").Parse(cstorPvcInfoTemplate)
-			if err != nil {
-				return errors.Wrap(err, "error displaying output for pvc info")
-			}
-			err = pvcInfoTemplate.Execute(os.Stdout, pvcInfo)
-			if err != nil {
-				return errors.Wrap(err, "error displaying cvc details")
-			}
-
-			targetPod, err := clientset.GetCstorVolumeTargetPod(item.Spec.VolumeName)
-			targetPodOutput := make([]string, 3)
-			if err == nil {
-				fmt.Printf("Target Details :\n----------------\n")
-				targetPodOutput[0] = "Namespace|Name|Ready|Status|Age|IP|Node"
-				targetPodOutput[1] = "---------|----|-----|------|---|--|----"
-				targetPodOutput[2] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
-					targetPod.Namespace,
-					targetPod.Name,
-					client.GetReadyContainers(targetPod.Status.ContainerStatuses),
-					targetPod.Status.Phase,
-					util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)),
-					targetPod.Status.PodIP,
-					targetPod.Spec.NodeName,
-				)
-			}
-			fmt.Println(util.FormatList(targetPodOutput))
-
-			if cvrs != nil {
-				fmt.Printf("\nReplica Details :\n----------------\n")
-				cvrOutput := make([]string, len(cvrs.Items)+2)
-				cvrOutput[0] = "Name|Total|Used|Status|Age"
-				cvrOutput[1] = "----|-----|----|------|---"
-				for i, cvr := range cvrs.Items {
-					cvrOutput[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s",
-						cvr.Name,
-						cvr.Status.Capacity.Total,
-						cvr.Status.Capacity.Used,
-						cvr.Status.Phase,
-						util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time)),
-					)
-				}
-				fmt.Println(util.FormatList(cvrOutput))
-			}
-
-			cvcInfoTemplate, err := template.New("cvc").Parse(detailsFromCVC)
-			if err != nil {
-				return errors.Wrap(err, "error displaying output for cvc info")
-			}
-			err = cvcInfoTemplate.Execute(os.Stdout, cvcInfo)
-			if err != nil {
-				return errors.Wrap(err, "error displaying cvc details")
-			}
-		} else {
-			pvcInfo := util.PVCInfo{}
-			pvcInfo.Name = item.Name
-			pvcInfo.Namespace = item.Namespace
-			pvcInfo.StorageClassName = *item.Spec.StorageClassName
-			quantity := item.Status.Capacity["storage"]
-			pvcInfo.Size = quantity.String()
-			pv, err := clientset.GetPV(item.Spec.VolumeName)
-			if err == nil {
+				pvcInfo.Name = item.Name
+				pvcInfo.Namespace = item.Namespace
 				pvcInfo.BoundVolume = item.Spec.VolumeName
-				pvcInfo.PVStatus = pv.Status.Phase
-				pvcInfo.CasType = client.GetCasType(pv, sc)
+				pvcInfo.CasType = casType
+				pvcInfo.StorageClassName = *item.Spec.StorageClassName
+
+				// fetching the underlying CStorVolume for the PV, to get the phase and size and notify the user
+				// if the CStorVolume is not found.
+				cv, err := clientset.GetcStorVolume(item.Spec.VolumeName)
+				if err != nil {
+					fmt.Println("Underlying CstorVolume is not found for: ", item.Name)
+				} else {
+					pvcInfo.Size = cv.Spec.Capacity.String()
+					pvcInfo.PVStatus = cv.Status.Phase
+				}
+
+				// fetching the underlying CStorVolumeConfig for the PV, to get the cvc info and Pool Name and notify the user
+				// if the CStorVolumeConfig is not found.
+				cvc, err := clientset.GetCVC(item.Spec.VolumeName)
+				if err != nil {
+					fmt.Println("Underlying CstorVolumeConfig is not found for: ", item.Name)
+				} else {
+					pvcInfo.Pool = cvc.Labels[cstortypes.CStorPoolClusterLabelKey]
+					cvcInfo.Name = cvc.Name
+					cvcInfo.ReplicaCount = len(cvc.Status.PoolInfo)
+					cvcInfo.PoolInfo = cvc.Status.PoolInfo
+					cvcInfo.Version = cvc.VersionDetails.Status.Current
+					cvcInfo.Upgrading = !(cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired)
+				}
+
+				// fetching the underlying CStorVolumeAttachment for the PV, to get the attached to node and notify the user
+				// if the CStorVolumeAttachment is not found.
+				cva, err := clientset.GetCVA(item.Spec.VolumeName)
+				if err != nil {
+					fmt.Println("Underlying CstorVolumeAttachment is not found for: ", item.Name)
+				} else {
+					pvcInfo.AttachedToNode = cva.Spec.Volume.OwnerNodeID
+				}
+
+				// fetching the underlying CStorVolumeReplicas for the PV, to list their details and notify the user
+				// none of the replicas are running if the CStorVolumeReplicas are not found.
+				cvrs, err := clientset.GetCVR(item.Spec.VolumeName)
+				if err == nil && len(cvrs.Items) > 0 {
+					pvcInfo.Used = client.GetUsedCapacityFromCVR(cvrs)
+				}
+
+				// Printing the Filled Details of the Cstor PVC
+				err = util.PrintByTemplate("pvc", cstorPvcInfoTemplate, pvcInfo)
+				if err != nil {
+					return err
+				}
+
+				// fetching the underlying TargetPod for the PV, to display its relevant details and notify the user
+				// if the TargetPod is not found.
+				targetPod, err := clientset.GetCstorVolumeTargetPod(item.Spec.VolumeName)
+				if err == nil {
+					targetPodOutput := make([]string, 2)
+					fmt.Printf("Target Details :\n")
+					targetPodOutput[0] = "Namespace|Name|Ready|Status|Age|IP|Node"
+					targetPodOutput[1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
+						targetPod.Namespace,
+						targetPod.Name,
+						client.GetReadyContainers(targetPod.Status.ContainerStatuses),
+						targetPod.Status.Phase,
+						util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)),
+						targetPod.Status.PodIP,
+						targetPod.Spec.NodeName,
+					)
+					fmt.Println(util.FormatList(targetPodOutput))
+				} else {
+					fmt.Println("Target Details :\nNo target pod exists for the CstorVolume")
+				}
+
+				// If CVRs are found list them and show relevant details else notify the user none of the replicas are
+				// running if not found
+				if cvrs != nil && len(cvrs.Items) > 0 {
+					fmt.Printf("\nReplica Details :\n")
+					cvrOutput := make([]string, len(cvrs.Items)+1)
+					cvrOutput[0] = "Name|Total|Used|Status|Age"
+					for i, cvr := range cvrs.Items {
+						cvrOutput[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s",
+							cvr.Name,
+							cvr.Status.Capacity.Total,
+							cvr.Status.Capacity.Used,
+							cvr.Status.Phase,
+							util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time)),
+						)
+					}
+					fmt.Println(util.FormatList(cvrOutput))
+				} else {
+					fmt.Println("\nReplica Details :\nNo running replicas found")
+				}
+
+				if cvc != nil {
+					// Printing the Filled Details of the CstorVolumeConfig
+					err = util.PrintByTemplate("cvc", detailsFromCVC, cvcInfo)
+					if err != nil {
+						return err
+					}
+				}
+
+			} else {
+				// TODO: Change below to support more casTypes.
+				// Incase a non-cstor pvc is entered show minimal details pertaining to the PVC
+				pvcInfo := util.PVCInfo{}
+				pvcInfo.Name = item.Name
+				pvcInfo.Namespace = item.Namespace
+				pvcInfo.StorageClassName = *item.Spec.StorageClassName
+				quantity := item.Status.Capacity[util.STORAGE]
+				pvcInfo.Size = quantity.String()
+				pv, err := clientset.GetPV(item.Spec.VolumeName)
+				if err == nil {
+					pvcInfo.BoundVolume = item.Spec.VolumeName
+					pvcInfo.PVStatus = pv.Status.Phase
+					pvcInfo.CasType = client.GetCasType(pv, sc)
+				}
+				err = util.PrintByTemplate("pvc", genericPvcInfoTemplate, pvcInfo)
+				if err != nil {
+					return err
+				}
 			}
-			cvcInfoTemplate, err := template.New("pvc").Parse(genericPvcInfoTemplate)
-			if err != nil {
-				return errors.Wrap(err, "error displaying output for pvc info")
-			}
-			err = cvcInfoTemplate.Execute(os.Stdout, pvcInfo)
-			if err != nil {
-				return errors.Wrap(err, "error displaying pvc details")
+			if len(pvcList.Items) > 1 && ind != len(pvcList.Items)-1 {
+				fmt.Println("-------------------------------------------------------------------------------------")
 			}
 		}
+	} else {
+		fmt.Println("No such PVCs were found in the", ns, "namespace")
 	}
 	return nil
 }

--- a/kubectl-openebs/cli/util/constant.go
+++ b/kubectl-openebs/cli/util/constant.go
@@ -31,16 +31,16 @@ const (
 	MaxWidth = 0
 	// Padding used in tabwriter
 	Padding = 4
-	// CasType key in label of PV
-	OPENEBS_CAS_TYPE_KEY = "openebs.io/cas-type"
+	// OpenEBSCasTypeKey present in label of PV
+	OpenEBSCasTypeKey = "openebs.io/cas-type"
 	// Unknown to be retuned when cas type is not known
-	UNKNOWN = "unknown"
-	// CasType key in parameter of SC
-	OPENBEBS_CAS_TYPE_KEY_SC = "cas-type"
-	// cstor cas type
-	CSTOR_CAS_TYPE = "cstor"
-	// cstor volume, replica healthy status
+	Unknown = "unknown"
+	// OpenEBSCasTypeKeySc present in parameter of SC
+	OpenEBSCasTypeKeySc = "cas-type"
+	// CstorCasType cas type name
+	CstorCasType = "cstor"
+	// Healthy cstor volume status
 	Healthy = "Healthy"
-	// Total Storage key in pvc status.capacity
-	STORAGE = "storage"
+	// StorageKey key present in pvc status.capacity
+	StorageKey = "storage"
 )

--- a/kubectl-openebs/cli/util/constant.go
+++ b/kubectl-openebs/cli/util/constant.go
@@ -41,4 +41,6 @@ const (
 	CSTOR_CAS_TYPE = "cstor"
 	// cstor volume, replica healthy status
 	Healthy = "Healthy"
+	// Total Storage key in pvc status.capacity
+	STORAGE = "storage"
 )

--- a/kubectl-openebs/cli/util/constant.go
+++ b/kubectl-openebs/cli/util/constant.go
@@ -31,4 +31,14 @@ const (
 	MaxWidth = 0
 	// Padding used in tabwriter
 	Padding = 4
+	// CasType key in label of PV
+	OPENEBS_CAS_TYPE_KEY = "openebs.io/cas-type"
+	// Unknown to be retuned when cas type is not known
+	UNKNOWN = "unknown"
+	// CasType key in parameter of SC
+	OPENBEBS_CAS_TYPE_KEY_SC = "cas-type"
+	// cstor cas type
+	CSTOR_CAS_TYPE = "cstor"
+	// cstor volume, replica healthy status
+	Healthy = "Healthy"
 )

--- a/kubectl-openebs/cli/util/k8s_utils.go
+++ b/kubectl-openebs/cli/util/k8s_utils.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/storage/v1"
+	"strconv"
+)
+
+// GetUsedCapacityFromCVR as the healthy replicas would have the correct used capacity details
+func GetUsedCapacityFromCVR(cvrList *cstorv1.CStorVolumeReplicaList) string {
+	for _, item := range cvrList.Items {
+		if item.Status.Phase == Healthy {
+			return item.Status.Capacity.Used
+		}
+	}
+	return ""
+}
+
+// GetCasType from the v1pv and v1sc, this is a fallback checker method, it checks
+// both the resource only if the castype is not found.
+func GetCasType(v1PV *corev1.PersistentVolume, v1SC *v1.StorageClass) string {
+	if val := GetCasTypeFromPV(v1PV); val != Unknown {
+		return val
+	}
+	if val := GetCasTypeFromSC(v1SC); val != Unknown {
+		return val
+	}
+	return Unknown
+}
+
+// GetCasTypeFromPV from the passed PersistentVolume or the Stora
+func GetCasTypeFromPV(v1PV *corev1.PersistentVolume) string {
+	if v1PV.ObjectMeta.Labels != nil {
+		if _, ok := v1PV.ObjectMeta.Labels[OpenEBSCasTypeKey]; ok {
+			return v1PV.ObjectMeta.Labels[OpenEBSCasTypeKey]
+		}
+	} else if v1PV.ObjectMeta.Annotations != nil {
+		if _, ok := v1PV.ObjectMeta.Annotations[OpenEBSCasTypeKey]; ok {
+			return v1PV.ObjectMeta.Annotations[OpenEBSCasTypeKey]
+		}
+	} else if v1PV.Spec.CSI != nil && v1PV.Spec.CSI.VolumeAttributes != nil {
+		if _, ok := v1PV.Spec.CSI.VolumeAttributes[OpenEBSCasTypeKey]; ok {
+			return v1PV.Spec.CSI.VolumeAttributes[OpenEBSCasTypeKey]
+		}
+	}
+	return Unknown
+}
+
+// GetCasTypeFromSC by passing the storage class
+func GetCasTypeFromSC(v1SC *v1.StorageClass) string {
+	if v1SC.Parameters != nil {
+		if _, ok := v1SC.Parameters[OpenEBSCasTypeKeySc]; ok {
+			return v1SC.Parameters[OpenEBSCasTypeKeySc]
+		}
+	}
+	return Unknown
+}
+
+// GetReadyContainers to show the number of ready vs total containers of pod i.e 2/3
+func GetReadyContainers(containers []corev1.ContainerStatus) string {
+	total := len(containers)
+	ready := 0
+	if total > 0 {
+		for _, item := range containers {
+			if item.Ready == true {
+				ready++
+			}
+		}
+	}
+	return strconv.Itoa(ready) + "/" + strconv.Itoa(total)
+}

--- a/kubectl-openebs/cli/util/k8s_utils.go
+++ b/kubectl-openebs/cli/util/k8s_utils.go
@@ -77,11 +77,9 @@ func GetCasTypeFromSC(v1SC *v1.StorageClass) string {
 func GetReadyContainers(containers []corev1.ContainerStatus) string {
 	total := len(containers)
 	ready := 0
-	if total > 0 {
-		for _, item := range containers {
-			if item.Ready == true {
-				ready++
-			}
+	for _, item := range containers {
+		if item.Ready {
+			ready++
 		}
 	}
 	return strconv.Itoa(ready) + "/" + strconv.Itoa(total)

--- a/kubectl-openebs/cli/util/types.go
+++ b/kubectl-openebs/cli/util/types.go
@@ -109,6 +109,8 @@ type CStorReplicaInfo struct {
 	Status string
 }
 
+// CstorPVCInfo struct will have all the details we want to give in the output for describe pvc
+// details section for cstor pvc
 type CstorPVCInfo struct {
 	Name             string
 	Namespace        string
@@ -122,6 +124,8 @@ type CstorPVCInfo struct {
 	PVStatus         v1.CStorVolumePhase
 }
 
+// CVCInfo struct will have all the details we want to give in the output for describe pvc
+// cvc section for cstor pvc
 type CVCInfo struct {
 	Name         string
 	ReplicaCount int
@@ -130,6 +134,8 @@ type CVCInfo struct {
 	Upgrading    bool
 }
 
+// PVCInfo struct will have all the details we want to give in the output for describe pvc
+// details section for non-cstor pvc
 type PVCInfo struct {
 	Name             string
 	Namespace        string

--- a/kubectl-openebs/cli/util/types.go
+++ b/kubectl-openebs/cli/util/types.go
@@ -108,3 +108,34 @@ type CStorReplicaInfo struct {
 	// ec. Healthy, Offline ,Degraded etc.
 	Status string
 }
+
+type CstorPVCInfo struct {
+	Name             string
+	Namespace        string
+	CasType          string
+	BoundVolume      string
+	AttachedToNode   string
+	Pool             string
+	StorageClassName string
+	Size             string
+	Used             string
+	PVStatus         v1.CStorVolumePhase
+}
+
+type CVCInfo struct {
+	Name         string
+	ReplicaCount int
+	PoolInfo     []string
+	Version      string
+	Upgrading    bool
+}
+
+type PVCInfo struct {
+	Name             string
+	Namespace        string
+	CasType          string
+	BoundVolume      string
+	StorageClassName string
+	Size             string
+	PVStatus         corev1.PersistentVolumePhase
+}

--- a/kubectl-openebs/cli/util/util.go
+++ b/kubectl-openebs/cli/util/util.go
@@ -18,11 +18,13 @@ package util
 
 import (
 	"fmt"
+	"html/template"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
 
@@ -69,4 +71,17 @@ func Duration(d time.Duration) string {
 		age = age + strconv.Itoa(int(secs)) + "s"
 	}
 	return age
+}
+
+// PrintByTemplate of the provided template and resource
+func PrintByTemplate(templateName string, resourceTemplate string, resource interface{}) error {
+	genericTemplate, err := template.New(templateName).Parse(resourceTemplate)
+	if err != nil {
+		return errors.Wrap(err, "error creating for "+templateName)
+	}
+	err = genericTemplate.Execute(os.Stdout, resource)
+	if err != nil {
+		return errors.Wrap(err, "error displaying by template for"+templateName)
+	}
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?
- This PR adds the ` kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]` command to the openebsctl.
- This PR adds some util functions and client functions specific to `cstor` storage engine.

### Command usage and output
 ` kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]`
- The above command can accept multiple pvc names in the same namespace and generates the describe for the pvcs.
- The above command displays information related to the only those sub CRs which exist, if they don't exist it would not show
   the details of that sub CR and would show message according to the missing CR.

<b>Valid Input's Output</b>
```
abhinandan@Dante:~/test-resources/openebs-crs/app$ kubectl openebs describe pvc mongo hostpath-vol

mongo Details :
Name             : mongo
Namespace        : default
Cas Type         : cstor
Bound Volume     : pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc
Attached To Node : minikube-1
Pool             : default-cstor-disk
Storage Class    : common-storageclass
Size             : 20Gi
Used             : 1.19G
PV Status	 : Healthy

Target Details :
Namespace  Name                                                             Ready  Status   Age     IP          Node
openebs    pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc-target-7487cbc8bc5ttzl  3/3    Running  41m35s  172.17.0.3  minikube

Replica Details :
Name                                                              Total  Used   Status   Age
pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc-default-cstor-disk-dcrm  1.04G  1.19G  Healthy  1h56m
pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc-default-cstor-disk-fp6v  1.04G  1.19G  Healthy  1h55m
pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc-default-cstor-disk-rhwj  715M   872M   Offline  1h55m

Additional Details from CVC :
Name          : pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc
Replica Count : 3
Pool Info     : [default-cstor-disk-dcrm default-cstor-disk-fp6v default-cstor-disk-rhwj]
Version       : 2.0.0-ee
Upgrading     : false

-------------------------------------------------------------------------------------

hostpath-vol Details :
Name             : hostpath-vol
Namespace        : default
Cas Type         : local-hostpath
Bound Volume     : pvc-7846ced1-ae66-4235-a847-53b4bcd3d46b
Storage Class    : local-hostpath
Size             : 0
PV Status	 : Released

```
<b>Invalid Input's Output</b>
```
abhinandan@Dante:~/test-resources/openebs-crs/app$ kubectl openebs describe pvc mongo hostpath-vol -n invalidns
No such PVCs were found in the invalidns namespace
```

### Drawback that needs to be covered in upcoming refactors
- `openebs` namespace is currently hardcoded to support only if resources are in `openebs` namespace because the `-n` flag is used to take the pvc namespace and same cannot be used to take the openebs namespace simultaneously.
- Solutions can be, either using a different flag to take the pvc namespace or to identify the openebs namespace from the cli itself without user intervention.