### PR TITLE
List & describe objects by name

### DIFF
--- a/client/k8s.go
+++ b/client/k8s.go
@@ -244,7 +244,7 @@ func (k K8sClient) NodeForVolume(volName string) (string, error) {
 	return podInfo.Items[0].Spec.NodeName, nil
 }
 
-// GetcStorPools using the OpenEBS's Client
+// GetcStorPools returns a list CSPIs
 func (k K8sClient) GetcStorPools() (*cstorv1.CStorPoolInstanceList, error) {
 	cStorPools, err := k.OpenebsCS.CstorV1().CStorPoolInstances("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -355,6 +355,7 @@ func (k K8sClient) GetcStorPoolsByName(names []string) (*cstorv1.CStorPoolInstan
 	}, nil
 }
 
+// GetcStorVolumesByNames gets the CStorVolume resource from all namespaces
 func (k K8sClient) GetcStorVolumesByNames(vols []string) (*cstorv1.CStorVolumeList, error) {
 	cVols, err := k.OpenebsCS.CstorV1().CStorVolumes("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -350,3 +350,25 @@ func (k K8sClient) GetcStorPoolsByName(names []string) (*cstorv1.CStorPoolInstan
 		Items: list,
 	}, nil
 }
+
+func (k K8sClient) GetcStorVolumesByNames(vols []string) (*cstorv1.CStorVolumeList, error) {
+	cVols, err := k.OpenebsCS.CstorV1().CStorVolumes("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error while while getting volumes")
+	}
+	csMap := make(map[string]cstorv1.CStorVolume)
+	for _, cv := range cVols.Items {
+		csMap[cv.Name] = cv
+	}
+	var list []cstorv1.CStorVolume
+	for _, name := range vols {
+		if pool, ok := csMap[name]; ok {
+			list = append(list, pool)
+		} else {
+			klog.Errorf("Error from server (NotFound): cStorVolume %s not found", name)
+		}
+	}
+	return &cstorv1.CStorVolumeList{
+		Items: list,
+	}, nil
+}

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -229,7 +229,7 @@ func (k K8sClient) GetCVR(name string) (*cstorv1.CStorVolumeReplicaList, error) 
 	}
 	if len(CStorVolumeReplicas.Items) == 0 {
 		// TODO: This came during rebase, this shouldn't be required
-		klog.Errorf("Error while getting cStor Volume Replica for  %s , no replicas found", name)
+		fmt.Printf("Error while getting cStor Volume Replica for %s, no replicas found\n", name)
 	}
 	return CStorVolumeReplicas, nil
 }

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -140,8 +140,8 @@ func (k K8sClient) GetStorageClass(driver string) (*v1.StorageClass, error) {
 	return scs, nil
 }
 
-// GetCSIVolume using the K8sClient's storage class client
-func (k K8sClient) GetCSIVolume(volname string) (*cstorv1.CStorVolumeAttachment, error) {
+// GetCStorVolumeAttachment using the K8sClient's storage class client
+func (k K8sClient) GetCStorVolumeAttachment(volname string) (*cstorv1.CStorVolumeAttachment, error) {
 	vol, err := k.OpenebsCS.CstorV1().CStorVolumeAttachments("").Get(context.TODO(), volname, metav1.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "error while while getting storage csi volume")
@@ -223,6 +223,10 @@ func (k K8sClient) GetCVR(name string) (*cstorv1.CStorVolumeReplicaList, error) 
 	CStorVolumeReplicas, err := k.OpenebsCS.CstorV1().CStorVolumeReplicas("").List(context.TODO(), metav1.ListOptions{LabelSelector: label})
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while getting cStor Volume Replica for volume %s", name)
+	}
+	if len(CStorVolumeReplicas.Items) == 0 {
+		// TODO: This came during rebase, this shouldn't be required
+		klog.Errorf("Error while getting cStor Volume Replica for  %s , no replicas found", name)
 	}
 	return CStorVolumeReplicas, nil
 }

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -347,7 +347,7 @@ func (k K8sClient) GetcStorPoolsByName(names []string) (*cstorv1.CStorPoolInstan
 		if pool, ok := poolMap[name]; ok {
 			list = append(list, pool)
 		} else {
-			klog.Errorf("Error from server (NotFound): pool %s not found", name)
+			fmt.Printf("Error from server (NotFound): pool %s not found\n", name)
 		}
 	}
 	return &cstorv1.CStorPoolInstanceList{
@@ -370,7 +370,7 @@ func (k K8sClient) GetcStorVolumesByNames(vols []string) (*cstorv1.CStorVolumeLi
 		if pool, ok := csMap[name]; ok {
 			list = append(list, pool)
 		} else {
-			klog.Errorf("Error from server (NotFound): cStorVolume %s not found", name)
+			fmt.Printf("Error from server (NotFound): cStorVolume %s not found\n", name)
 		}
 	}
 	return &cstorv1.CStorVolumeList{

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -75,7 +75,7 @@ func NewCmdDescribeVolume() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "volume",
 		Aliases: []string{"volumes", "vol", "v"},
-		Short:   "Displays Openebs information",
+		Short:   "Displays Openebs volume information",
 		Long:    volumeInfoCommandHelpText,
 		Example: `kubectl openebs describe volume [vol]`,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -18,8 +18,6 @@ package describe
 
 import (
 	"fmt"
-	"html/template"
-	"os"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 
@@ -154,14 +152,9 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		}
 
 		// Print the output for the portal status info
-		tmpl, err := template.New("volume").Parse(volInfoTemplate)
+		err = util.PrintByTemplate("volume", volInfoTemplate, volume)
 		if err != nil {
-			return errors.Wrap(err, "error displaying output for volume info")
-		}
-		err = tmpl.Execute(os.Stdout, volume)
-		if err != nil {
-			return errors.Wrap(err, "error displaying volume details")
-
+			return err
 		}
 
 		portalInfo := util.PortalInfo{
@@ -173,14 +166,9 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		}
 
 		// Print the output for the portal status info
-		tmpl, err = template.New("PortalInfo").Parse(portalTemplate)
+		err = util.PrintByTemplate("PortalInfo", portalTemplate, portalInfo)
 		if err != nil {
 			return errors.Wrap(err, "error creating output for portal info")
-		}
-		err = tmpl.Execute(os.Stdout, portalInfo)
-		if err != nil {
-			fmt.Println(err, "error displaying target portal detail")
-			return nil
 		}
 
 		replicaCount := volumeInfo.Spec.ReplicationFactor

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -106,16 +106,19 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		volumeInfo, err := clientset.GetcStorVolume(volName)
 		if err != nil {
 			fmt.Printf("failed to get CStorVolume %s\n", volName)
+			continue
 		}
 		//2. Persistent Volume info
 		pvInfo, err := clientset.GetPV(volName)
 		if err != nil {
 			fmt.Printf("failed to get PV %s\n", volName)
+			continue
 		}
 		//3. cStor Volume Config
 		cvcInfo, err := clientset.GetCVC(volName)
 		if err != nil {
 			fmt.Printf("failed to get cStor Volume config for %s", volName)
+			continue
 		}
 
 		//4. Get Node for Target Pod from the openebs-ns
@@ -132,6 +135,7 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		cvrInfo, err := clientset.GetCVR(volName)
 		if err != nil {
 			fmt.Printf("failed to get cStor Volume Replicas for %s\n", volName)
+			continue
 		}
 		cSPCLabel := cstortypes.CStorPoolClusterLabelKey
 		volume := util.VolumeInfo{
@@ -189,8 +193,7 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 			out[i+2] = fmt.Sprintf("%s|%s|%s",
 				cvr.ObjectMeta.Name,
 				cvr.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
-				cvr.Status.Phase,
-			)
+				cvr.Status.Phase)
 		}
 		fmt.Println(util.FormatList(out))
 	}

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -196,6 +196,7 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 				cvr.Status.Phase)
 		}
 		fmt.Println(util.FormatList(out))
+		fmt.Println()
 	}
 	return nil
 }

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"k8s.io/klog"
 )
 
 var (
@@ -36,7 +35,7 @@ This command fetches information and status of the various
 aspects of a cStor Volume such as ISCSI, Controller, and Replica.
 
 #
-$ kubectl openebs describe [pool|volume] [name]
+$ kubectl openebs describe [volume] [names...]
 
 `
 )
@@ -123,10 +122,7 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 	}
 
 	//4. Get Node Name for Target Pod
-	NodeName, err := clientset.NodeForVolume(volName)
-	if err != nil {
-		klog.Errorf("error executeing volume info command, getting Node for Volume %s:{%s}", volName, err)
-	}
+	NodeName := cvcInfo.Publish.NodeID
 
 	//5. cStor Volume Replicas
 	cvrInfo, err := clientset.GetCVR(volName)

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -98,109 +98,108 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		return errors.Wrap(err, "failed to execute volume info command")
 	}
 	// TODO: Print all volume info present in args or print all volume info if no args given
-	if len(vols) != 1 {
+	if len(vols) == 0 {
 		return errors.New("Please give at least one volume to describe")
 	}
-	volName := vols[0]
-	// Fetch all details of a volume is called to get the volume controller's
-	// info such as controller's IP, status, iqn, replica IPs etc.
-	//1. cStor volume info
-	volumeInfo, err := clientset.GetcStorVolume(volName)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute volume info command, getting cStor volumes")
-	}
-	//2. Persistent Volume info
-	pvInfo, err := clientset.GetPV(volName)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute volume info command, getting persistant volumes")
-	}
+	for _, volName := range vols {
+		// Fetch all details of a volume is called to get the volume controller's
+		// info such as controller's IP, status, iqn, replica IPs etc.
+		//1. cStor volume info
+		volumeInfo, err := clientset.GetcStorVolume(volName)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute volume info command, getting cStor volumes")
+		}
+		//2. Persistent Volume info
+		pvInfo, err := clientset.GetPV(volName)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute volume info command, getting persistant volumes")
+		}
+		//3. cStor Volume Config
+		cvcInfo, err := clientset.GetCVC(volName)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute volume info command, getting cStor Volume config")
+		}
 
-	//3. cStor Volume Config
-	cvcInfo, err := clientset.GetCVC(volName)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute volume info command, getting cStor Volume config")
+		//4. Get Node Name for Target Pod
+		NodeName := cvcInfo.Publish.NodeID
+
+		//5. cStor Volume Replicas
+		cvrInfo, err := clientset.GetCVR(volName)
+		if err != nil {
+			return errors.Wrap(err, "failed to execute volume info command, getting cStor Volume Replicas")
+		}
+
+		cSPCLabel := cstortypes.CStorPoolClusterLabelKey
+
+		volume := util.VolumeInfo{
+			AccessMode:              util.AccessModeToString(pvInfo.Spec.AccessModes),
+			Capacity:                volumeInfo.Status.Capacity.String(),
+			CSPC:                    cvcInfo.Labels[cSPCLabel],
+			CSIDriver:               pvInfo.Spec.CSI.Driver,
+			CSIVolumeAttachmentName: pvInfo.Spec.CSI.VolumeHandle,
+			Name:                    volumeInfo.Name,
+			Namespace:               volumeInfo.Namespace,
+			PVC:                     pvInfo.Spec.ClaimRef.Name,
+			ReplicaCount:            volumeInfo.Spec.ReplicationFactor,
+			VolumePhase:             pvInfo.Status.Phase,
+			StorageClass:            pvInfo.Spec.StorageClassName,
+			Version:                 util.CheckVersion(volumeInfo.VersionDetails),
+			Size:                    volumeInfo.Status.Capacity.String(),
+			Status:                  volumeInfo.Status.Phase,
+		}
+
+		// Print the output for the portal status info
+		tmpl, err := template.New("volume").Parse(volInfoTemplate)
+		if err != nil {
+			return errors.Wrap(err, "error displaying output for volume info")
+		}
+		err = tmpl.Execute(os.Stdout, volume)
+		if err != nil {
+			return errors.Wrap(err, "error displaying volume details")
+
+		}
+
+		portalInfo := util.PortalInfo{
+			IQN:            volumeInfo.Spec.Iqn,
+			VolumeName:     volumeInfo.Name,
+			Portal:         volumeInfo.Spec.TargetPortal,
+			TargetIP:       volumeInfo.Spec.TargetIP,
+			TargetNodeName: NodeName,
+		}
+
+		// Print the output for the portal status info
+		tmpl, err = template.New("PortalInfo").Parse(portalTemplate)
+		if err != nil {
+			return errors.Wrap(err, "error creating output for portal info")
+		}
+		err = tmpl.Execute(os.Stdout, portalInfo)
+		if err != nil {
+			fmt.Println(err, "error displaying target portal detail")
+			return nil
+		}
+
+		replicaCount := volumeInfo.Spec.ReplicationFactor
+		// This case will occur only if user has manually specified zero replica.
+		// or if none of the replicas are healthy & running
+		if replicaCount == 0 || len(volumeInfo.Status.ReplicaStatuses) == 0 {
+			fmt.Println("None of the replicas are running")
+			//please check the volume pod's status by running [kubectl describe pvc -l=openebs/replica --all-namespaces]\Oor try again later.")
+			return nil
+		}
+
+		// Print replica details
+		fmt.Printf("Replica Details :\n----------------\n")
+		out := make([]string, len(cvrInfo.Items)+2)
+		out[0] = "Name|Pool Instance|Status"
+		out[1] = "----|-------------|------"
+		for i, cvr := range cvrInfo.Items {
+			out[i+2] = fmt.Sprintf("%s|%s|%s",
+				cvr.ObjectMeta.Name,
+				cvr.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
+				cvr.Status.Phase,
+			)
+		}
+		fmt.Println(util.FormatList(out))
 	}
-
-	//4. Get Node Name for Target Pod
-	NodeName := cvcInfo.Publish.NodeID
-
-	//5. cStor Volume Replicas
-	cvrInfo, err := clientset.GetCVR(volName)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute volume info command, getting cStor Volume Replicas")
-	}
-
-	cSPCLabel := cstortypes.CStorPoolClusterLabelKey
-
-	volume := util.VolumeInfo{
-		AccessMode:              util.AccessModeToString(pvInfo.Spec.AccessModes),
-		Capacity:                volumeInfo.Status.Capacity.String(),
-		CSPC:                    cvcInfo.Labels[cSPCLabel],
-		CSIDriver:               pvInfo.Spec.CSI.Driver,
-		CSIVolumeAttachmentName: pvInfo.Spec.CSI.VolumeHandle,
-		Name:                    volumeInfo.Name,
-		Namespace:               volumeInfo.Namespace,
-		PVC:                     pvInfo.Spec.ClaimRef.Name,
-		ReplicaCount:            volumeInfo.Spec.ReplicationFactor,
-		VolumePhase:             pvInfo.Status.Phase,
-		StorageClass:            pvInfo.Spec.StorageClassName,
-		Version:                 util.CheckVersion(volumeInfo.VersionDetails),
-		Size:                    volumeInfo.Status.Capacity.String(),
-		Status:                  volumeInfo.Status.Phase,
-	}
-
-	// Print the output for the portal status info
-	tmpl, err := template.New("volume").Parse(volInfoTemplate)
-	if err != nil {
-		return errors.Wrap(err, "error displaying output for volume info")
-	}
-	err = tmpl.Execute(os.Stdout, volume)
-	if err != nil {
-		return errors.Wrap(err, "error displaying volume details")
-
-	}
-
-	portalInfo := util.PortalInfo{
-		IQN:            volumeInfo.Spec.Iqn,
-		VolumeName:     volumeInfo.Name,
-		Portal:         volumeInfo.Spec.TargetPortal,
-		TargetIP:       volumeInfo.Spec.TargetIP,
-		TargetNodeName: NodeName,
-	}
-
-	// Print the output for the portal status info
-	tmpl, err = template.New("PortalInfo").Parse(portalTemplate)
-	if err != nil {
-		return errors.Wrap(err, "error creating output for portal info")
-	}
-	err = tmpl.Execute(os.Stdout, portalInfo)
-	if err != nil {
-		fmt.Println(err, "error displaying target portal detail")
-		return nil
-	}
-
-	replicaCount := volumeInfo.Spec.ReplicationFactor
-	// This case will occur only if user has manually specified zero replica.
-	// or if none of the replicas are healthy & running
-	if replicaCount == 0 || len(volumeInfo.Status.ReplicaStatuses) == 0 {
-		fmt.Println("None of the replicas are running")
-		//please check the volume pod's status by running [kubectl describe pvc -l=openebs/replica --all-namespaces]\Oor try again later.")
-		return nil
-	}
-
-	// Print replica details
-	fmt.Printf("Replica Details :\n----------------\n")
-	out := make([]string, len(cvrInfo.Items)+2)
-	out[0] = "Name|Pool Instance|Status"
-	out[1] = "----|-------------|------"
-	for i, cvr := range cvrInfo.Items {
-		out[i+2] = fmt.Sprintf("%s|%s|%s",
-			cvr.ObjectMeta.Name,
-			cvr.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
-			cvr.Status.Phase,
-		)
-	}
-
-	fmt.Println(util.FormatList(out))
 	return nil
 }

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -121,9 +121,13 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		}
 
 		//4. Get Node for Target Pod from the openebs-ns
-		nodeName, err := clientset.NodeForVolume(volName)
+		node, err := clientset.GetCStorVolumeAttachment(volName)
+		var nodeName string
 		if err != nil {
+			nodeName = "N/A"
 			fmt.Printf("failed to get CStorVolumeAttachments for %s\n", volName)
+		} else {
+			nodeName = node.Spec.Volume.OwnerNodeID
 		}
 
 		//5. cStor Volume Replicas

--- a/kubectl-openebs/cli/command/get/pool_list.go
+++ b/kubectl-openebs/cli/command/get/pool_list.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/openebsctl/client"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/pkg/errors"
@@ -58,17 +59,22 @@ func NewCmdGetPool() *cobra.Command {
 func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
 	client, err := client.NewK8sClient(ns)
 	util.CheckErr(err, util.Fatal)
-	cpools, err := client.GetcStorPools()
+	var cpools *v1.CStorPoolInstanceList
+	if len(pools) == 0 {
+		// List all
+		cpools, err = client.GetcStorPools()
+	} else {
+		// Get one or more
+		cpools, err = client.GetcStorPoolsByName(pools)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error listing pools")
 	}
-
 	out := make([]string, len(cpools.Items)+2)
 	out[0] = "Name|HostName|Free|Capacity|ReadOnly|ProvisionedReplicas|HealthyReplicas|Status|Age"
 	out[1] = "----|--------|----|--------|--------|-------------------|---------------|------|---"
-	i := 2
-	for _, item := range cpools.Items {
-		out[i] = fmt.Sprintf("%s|%s|%s|%s|%v|%d|%d|%s|%s",
+	for i, item := range cpools.Items {
+		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%v|%d|%d|%s|%s",
 			item.ObjectMeta.Name,
 			item.ObjectMeta.Labels["kubernetes.io/hostname"],
 			item.Status.Capacity.Free.String(),
@@ -79,11 +85,10 @@ func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
 			item.Status.Phase,
 			util.Duration(time.Since(item.ObjectMeta.CreationTimestamp.Time)),
 		)
-		i++
-	}
-	if len(out) == 2 {
-		fmt.Println("No Pools are found")
-		return nil
+		if len(out) == 2 {
+			fmt.Println("No Pools are found")
+			return nil
+		}
 	}
 	fmt.Println(util.FormatList(out))
 	return nil

--- a/kubectl-openebs/cli/command/get/pool_list.go
+++ b/kubectl-openebs/cli/command/get/pool_list.go
@@ -48,17 +48,16 @@ func NewCmdGetPool() *cobra.Command {
 				ns = "openebs"
 			}
 			// TODO: De-couple CLI code, logic code, API code
-			util.CheckErr(RunPoolsList(cmd, ns), util.Fatal)
+			util.CheckErr(RunPoolsList(cmd, args, ns), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 //RunPoolsList fetchs & lists the pools
-func RunPoolsList(cmd *cobra.Command, ns string) error {
+func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
 	client, err := client.NewK8sClient(ns)
 	util.CheckErr(err, util.Fatal)
-
 	cpools, err := client.GetcStorPools()
 	if err != nil {
 		return errors.Wrap(err, "error listing pools")

--- a/kubectl-openebs/cli/command/get/pool_list.go
+++ b/kubectl-openebs/cli/command/get/pool_list.go
@@ -64,12 +64,12 @@ func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
 	}
 
 	out := make([]string, len(cpools.Items)+2)
-	out[0] = "Name|Namespace|HostName|Free|Capacity|ReadOnly|ProvisionedReplicas|HealthyReplicas|Status|Age"
-	out[1] = "----|---------|--------|----|--------|--------|-------------------|---------------|------|---"
-	for i, item := range cpools.Items {
-		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s|%v|%d|%d|%s|%s",
+	out[0] = "Name|HostName|Free|Capacity|ReadOnly|ProvisionedReplicas|HealthyReplicas|Status|Age"
+	out[1] = "----|--------|----|--------|--------|-------------------|---------------|------|---"
+	i := 2
+	for _, item := range cpools.Items {
+		out[i] = fmt.Sprintf("%s|%s|%s|%s|%v|%d|%d|%s|%s",
 			item.ObjectMeta.Name,
-			item.ObjectMeta.Namespace,
 			item.ObjectMeta.Labels["kubernetes.io/hostname"],
 			item.Status.Capacity.Free.String(),
 			item.Status.Capacity.Total.String(),
@@ -79,6 +79,7 @@ func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
 			item.Status.Phase,
 			util.Duration(time.Since(item.ObjectMeta.CreationTimestamp.Time)),
 		)
+		i++
 	}
 	if len(out) == 2 {
 		fmt.Println("No Pools are found")

--- a/kubectl-openebs/cli/command/get/volume_list.go
+++ b/kubectl-openebs/cli/command/get/volume_list.go
@@ -42,14 +42,14 @@ func NewCmdGetVolume() *cobra.Command {
 		Short:   "Displays status information about Volume(s)",
 		Long:    volumesListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(RunVolumesList(cmd), util.Fatal)
+			util.CheckErr(RunVolumesList(cmd, args), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 // RunVolumesList lists the volumes
-func RunVolumesList(cmd *cobra.Command) error {
+func RunVolumesList(cmd *cobra.Command, vols []string) error {
 	// TODO: Why is this working?
 	client, err := client.NewK8sClient("")
 	util.CheckErr(err, util.Fatal)

--- a/kubectl-openebs/cli/command/get/volume_list.go
+++ b/kubectl-openebs/cli/command/get/volume_list.go
@@ -19,6 +19,7 @@ package get
 import (
 	"fmt"
 
+	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/openebsctl/client"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/pkg/errors"
@@ -50,10 +51,14 @@ func NewCmdGetVolume() *cobra.Command {
 
 // RunVolumesList lists the volumes
 func RunVolumesList(cmd *cobra.Command, vols []string) error {
-	// TODO: Why is this working?
 	client, err := client.NewK8sClient("")
 	util.CheckErr(err, util.Fatal)
-	cvols, err := client.GetcStorVolumes()
+	var cvols *v1.CStorVolumeList
+	if len(vols) == 0 {
+		cvols, err = client.GetcStorVolumes()
+	} else {
+		cvols, err = client.GetcStorVolumesByNames(vols)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error listing volumes")
 	}


### PR DESCRIPTION
# What's changing?

- GetByObjectName support has been added; similar to `kubectl get po pod-name` which only shows one pod.
- Existing functionality without the object name doesn't change

# Summary of under-the-hood changes.

- the namespace column has been omitted from the `kubectl openebs get volumes` output as `PersistentVolume` is not a namespaced resource, that namespace is of the `CStorVolume` resource, it can be re-added if required.

# Minor changes

- typos in logs are fixed



# User visible change

```bash
# Before: All resources were listed/described
$ kubectl openebs get volumes pvc-abcd-1234
NAME
--------
pvc-defg-1234
pvc-pqrst...
pvc-abcd-1234

# After: Only the requested resources are listed/described
$ kubectl openebs get volumes pvc-abcd-1234
NAME
--------
pvc-abcd-1234
```