### PR TITLE
[Major refactors] Add cli-runtime format for all output, humanize all units, add single flag for openebs ns, add openebs determination logic for all commands

### DIFF
--- a/client/k8s.go
+++ b/client/k8s.go
@@ -131,6 +131,7 @@ func homeDir() string {
 	}
 	return os.Getenv("KUBECONFIG")
 }
+
 // GetOpenEBSNamespace from the specific engine component based on cas-type
 func (k K8sClient) GetOpenEBSNamespace(casType string) (string, error) {
 	pods, err := k.K8sCS.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{LabelSelector: fmt.Sprintf("openebs.io/component-name=%s", util.CasTypeAndComponentNameMap[strings.ToLower(casType)])})
@@ -144,7 +145,7 @@ func (k K8sClient) GetOpenEBSNamespace(casType string) (string, error) {
 func (k K8sClient) GetStorageClass(driver string) (*v1.StorageClass, error) {
 	scs, err := k.K8sCS.StorageV1().StorageClasses().Get(context.TODO(), driver, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "error while while getting storage class")
+		return nil, errors.Wrap(err, "error while getting storage class")
 	}
 	return scs, nil
 }
@@ -165,7 +166,7 @@ func (k K8sClient) GetCStorVolumeAttachment(volname string) (*cstorv1.CStorVolum
 func (k K8sClient) GetcStorVolumes() (*cstorv1.CStorVolumeList, error) {
 	cStorVols, err := k.OpenebsCS.CstorV1().CStorVolumes("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while while getting volumes")
+		return nil, errors.Wrapf(err, "Error while getting volumes")
 	}
 	return cStorVols, nil
 }
@@ -174,7 +175,7 @@ func (k K8sClient) GetcStorVolumes() (*cstorv1.CStorVolumeList, error) {
 func (k K8sClient) GetcStorVolume(volName string) (*cstorv1.CStorVolume, error) {
 	volInfo, err := k.OpenebsCS.CstorV1().CStorVolumes(k.Ns).Get(context.TODO(), volName, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "error while while getting volume %s", volName)
+		return nil, errors.Wrapf(err, "error while getting volume %s", volName)
 	}
 	return volInfo, nil
 }
@@ -185,7 +186,7 @@ func (k K8sClient) GetCStorVolumeInfoMap(node string) (map[string]*util.Volume, 
 	volumes := make(map[string]*util.Volume)
 	cstorVA, err := k.OpenebsCS.CstorV1().CStorVolumeAttachments("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return volumes, errors.Wrap(err, "error while while getting storage volume attachments")
+		return volumes, errors.Wrap(err, "error while getting storage volume attachments")
 	}
 	for _, i := range cstorVA.Items {
 		if i.Spec.Volume.Name == "" {
@@ -215,7 +216,7 @@ func (k K8sClient) GetCStorVolumeInfoMap(node string) (map[string]*util.Volume, 
 func (k K8sClient) GetPV(name string) (*corev1.PersistentVolume, error) {
 	vol, err := k.K8sCS.CoreV1().PersistentVolumes().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrap(err, "error while while getting persistant volume")
+		return nil, errors.Wrap(err, "error while getting persistant volume")
 	}
 	return vol, nil
 }
@@ -310,7 +311,7 @@ func (k K8sClient) GetCstorVolumeTargetPod(volumeClaim string, volumeName string
 func (k K8sClient) GetcStorPool(poolName string) (*cstorv1.CStorPoolInstance, error) {
 	cStorPool, err := k.OpenebsCS.CstorV1().CStorPoolInstances(k.Ns).Get(context.TODO(), poolName, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while while getting cspi")
+		return nil, errors.Wrapf(err, "Error while getting cspi")
 	}
 	return cStorPool, nil
 }
@@ -319,7 +320,7 @@ func (k K8sClient) GetcStorPool(poolName string) (*cstorv1.CStorPoolInstance, er
 func (k K8sClient) GetBlockDevice(bd string) (*v1alpha1.BlockDevice, error) {
 	blockDevice, err := k.OpenebsCS.OpenebsV1alpha1().BlockDevices(k.Ns).Get(context.TODO(), bd, metav1.GetOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while while getting block device")
+		return nil, errors.Wrapf(err, "Error while getting block device")
 	}
 	return blockDevice, nil
 }
@@ -371,7 +372,7 @@ func (k K8sClient) GetcStorPoolsByName(names []string) (*cstorv1.CStorPoolInstan
 func (k K8sClient) GetcStorVolumesByNames(vols []string) (*cstorv1.CStorVolumeList, error) {
 	cVols, err := k.OpenebsCS.CstorV1().CStorVolumes("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error while while getting volumes")
+		return nil, errors.Wrapf(err, "Error while getting volumes")
 	}
 	csMap := make(map[string]cstorv1.CStorVolume)
 	for _, cv := range cVols.Items {

--- a/client/k8s.go
+++ b/client/k8s.go
@@ -198,7 +198,7 @@ func (k K8sClient) GetCStorVolumeInfoMap(node string) (map[string]*util.Volume, 
 		}
 		vol := &util.Volume{
 			StorageClass:            pv.Spec.StorageClassName,
-			Node:                    i.ObjectMeta.OwnerReferences[0].Name,
+			Node:                    i.Labels["nodeID"],
 			PVC:                     pv.Spec.ClaimRef.Name,
 			CSIVolumeAttachmentName: i.Name,
 			AttachementStatus:       string(pv.Status.Phase),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openebs/openebsctl
 go 1.14
 
 require (
+	github.com/dustin/go-humanize v1.0.0
 	github.com/openebs/api/v2 v2.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/ryanuber/columnize v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/kubectl-openebs/cli/command/commands.go
+++ b/kubectl-openebs/cli/command/commands.go
@@ -29,6 +29,7 @@ import (
 
 // NewOpenebsCommand creates the `openebs` command and its nested children.
 func NewOpenebsCommand() *cobra.Command {
+	var openebsNs string
 	cmd := &cobra.Command{
 		Use:   "openebs",
 		Short: "openebs is a a kubectl plugin for interacting with OpenEBS storage components",
@@ -46,6 +47,7 @@ Find out more about OpenEBS on https://docs.openebs.io/`,
 		get.NewCmdGet(cmd),
 		describe.NewCmdDescribe(cmd),
 	)
+	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	_ = flag.CommandLine.Parse([]string{})
 	_ = viper.BindPFlag("namespace", cmd.PersistentFlags().Lookup("namespace"))

--- a/kubectl-openebs/cli/command/describe/pool_info.go
+++ b/kubectl-openebs/cli/command/describe/pool_info.go
@@ -18,6 +18,7 @@ package describe
 
 import (
 	"fmt"
+
 	"github.com/dustin/go-humanize"
 	"github.com/openebs/openebsctl/client"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
@@ -49,7 +50,6 @@ STATUS	         : {{.Status}}
 RAID TYPE        : {{.RaidType}}
 
 `
-
 )
 
 // NewCmdDescribePool displays OpenEBS cStor pool instance information.
@@ -61,7 +61,7 @@ func NewCmdDescribePool() *cobra.Command {
 		Long:    poolInfoCommandHelpText,
 		Example: `kubectl openebs describe pool cspi-one -n openebs`,
 		Run: func(cmd *cobra.Command, args []string) {
-			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
 			util.CheckErr(RunPoolInfo(cmd, args, openebsNs), util.Fatal)
 		},
 	}
@@ -123,32 +123,32 @@ func RunPoolInfo(cmd *cobra.Command, pools []string, openebsNs string) error {
 		bd, err := clientset.GetBlockDevice(item)
 		if err != nil {
 			fmt.Printf("Could not find the blockdevice : %s\n", item)
-		}else{
-			bdRows = append(bdRows,  metav1.TableRow{Cells: []interface{}{bd.Name, humanize.IBytes(bd.Spec.Capacity.Storage), bd.Status.State}})
+		} else {
+			bdRows = append(bdRows, metav1.TableRow{Cells: []interface{}{bd.Name, humanize.IBytes(bd.Spec.Capacity.Storage), bd.Status.State}})
 		}
 	}
-	 if len(bdRows) != 0 {
-	 	fmt.Printf("Blockdevice details :\n" + "---------------------\n")
-		 util.TablePrinter(util.BDListColumnDefinations, bdRows, printers.PrintOptions{Wide: true})
-	 }else{
-		 fmt.Printf("Could not find any blockdevice that belongs to the pool")
-	 }
+	if len(bdRows) != 0 {
+		fmt.Printf("Blockdevice details :\n" + "---------------------\n")
+		util.TablePrinter(util.BDListColumnDefinations, bdRows, printers.PrintOptions{Wide: true})
+	} else {
+		fmt.Printf("Could not find any blockdevice that belongs to the pool")
+	}
 
 	// Fetch info for provisional replica
 	var cvrRows []metav1.TableRow
 	CVRsInPool, err := clientset.GetCVRByPoolName(poolName)
 	if err != nil {
 		fmt.Printf("None of the replicas are running")
-	}else{
+	} else {
 		for _, cvr := range CVRsInPool.Items {
-			cvrRows = append(cvrRows,  metav1.TableRow{Cells: []interface{}{
+			cvrRows = append(cvrRows, metav1.TableRow{Cells: []interface{}{
 				cvr.Name,
 				clientset.GetPVCNameByCVR(cvr.Labels["openebs.io/persistent-volume"]),
 				util.ConvertToIBytes(cvr.Status.Capacity.Total),
 				cvr.Status.Phase}})
 		}
 	}
-	if len(cvrRows) !=0 {
+	if len(cvrRows) != 0 {
 		fmt.Printf("\nReplica Details :\n-----------------\n")
 		util.TablePrinter(util.PoolReplicaColumnDefinations, cvrRows, printers.PrintOptions{Wide: true})
 	}

--- a/kubectl-openebs/cli/command/describe/pool_info.go
+++ b/kubectl-openebs/cli/command/describe/pool_info.go
@@ -17,10 +17,14 @@ limitations under the License.
 package describe
 
 import (
+	"fmt"
+	"github.com/dustin/go-humanize"
 	"github.com/openebs/openebsctl/client"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 )
 
 var (
@@ -36,34 +40,16 @@ const (
 	cStorPoolInstanceInfoTemplate = `
 {{.Name}} Details :
 ----------------
-Name             : {{.Name}}
-Hostname         : {{.HostName}}
-Size             : {{.Size}}
-Free Capacity    : {{.FreeCapacity}}
-Read Only Status : {{.ReadOnlyStatus}}
-Status	         : {{.Status}}
-RAID Type        : {{.RaidType}}
+NAME             : {{.Name}}
+HOSTNAME         : {{.HostName}}
+SIZE             : {{.Size}}
+FREE CAPACITY    : {{.FreeCapacity}}
+READ ONLY STATUS : {{.ReadOnlyStatus}}
+STATUS	         : {{.Status}}
+RAID TYPE        : {{.RaidType}}
 
 `
 
-	blockDevicesInfoFromCSPI = `
-Block Device Details :
-----------------
-Name     : {{.Name}}
-Capacity : {{.Capacity}}
-State   : {{.State}}
-
-`
-
-	provisionedReplicasInfoFromCSPI = `
-Provisioned Replicas Details :
-----------------
-Name     : {{.Name}}
-PVC Name : {{.PvcName}}
-Size     : {{.Size}}
-Status	 : {{.Status}}
-
-`
 )
 
 // NewCmdDescribePool displays OpenEBS cStor pool instance information.
@@ -75,26 +61,29 @@ func NewCmdDescribePool() *cobra.Command {
 		Long:    poolInfoCommandHelpText,
 		Example: `kubectl openebs describe pool cspi-one -n openebs`,
 		Run: func(cmd *cobra.Command, args []string) {
-			var namespace string // This namespace belongs to the CSPI entered
-			if namespace, _ = cmd.Flags().GetString("namespace"); namespace == "" {
-				// NOTE: The error comes as nil even when the ns flag is not specified
-				namespace = "openebs"
-			}
-			util.CheckErr(RunPoolInfo(cmd, args, namespace), util.Fatal)
+			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			util.CheckErr(RunPoolInfo(cmd, args, openebsNs), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 // RunPoolInfo method runs info command and make call to DisplayPoolInfo to display the results
-func RunPoolInfo(cmd *cobra.Command, pools []string, ns string) error {
+func RunPoolInfo(cmd *cobra.Command, pools []string, openebsNs string) error {
 	if len(pools) != 1 {
 		return errors.New("Please give one cspi name to describe")
 	}
-
-	clientset, err := client.NewK8sClient(ns)
+	clientset, err := client.NewK8sClient(openebsNs)
 	if err != nil {
 		return errors.Wrap(err, "Failed to execute pool info command")
+	}
+
+	if openebsNs == "" {
+		nsFromCli, err := clientset.GetOpenEBSNamespace(util.CstorCasType)
+		if err != nil {
+			return errors.Wrap(err, "Error determining the openebs namespace, please specify using \"--openebs-namespace\" flag")
+		}
+		clientset.Ns = nsFromCli
 	}
 
 	// Fetch the CSPI object by passing the name of CSPI taken through CLI in ns namespace
@@ -107,8 +96,8 @@ func RunPoolInfo(cmd *cobra.Command, pools []string, ns string) error {
 	poolDetails := util.PoolInfo{
 		Name:           poolInfo.Name,
 		HostName:       poolInfo.Spec.HostName,
-		Size:           poolInfo.Status.Capacity.Total.String(),
-		FreeCapacity:   poolInfo.Status.Capacity.Free.String(),
+		Size:           util.ConvertToIBytes(poolInfo.Status.Capacity.Total.String()),
+		FreeCapacity:   util.ConvertToIBytes(poolInfo.Status.Capacity.Free.String()),
 		ReadOnlyStatus: poolInfo.Status.ReadOnly,
 		Status:         poolInfo.Status.Phase,
 		RaidType:       poolInfo.Spec.PoolConfig.DataRaidGroupType,
@@ -122,56 +111,46 @@ func RunPoolInfo(cmd *cobra.Command, pools []string, ns string) error {
 		BlockDevicesInPool = append(BlockDevicesInPool, item.GetBlockDevices()...)
 	}
 
-	// Fetch info for every block device
-	var BdInfo []util.BlockDevicesInfoInPool
-	for _, item := range BlockDevicesInPool {
-		bd, err := clientset.GetBlockDevice(item)
-		if err != nil {
-			return errors.Wrap(err, "Error getting block device info")
-		}
-
-		BdInfo = append(BdInfo, util.BlockDevicesInfoInPool{
-			Name:     bd.Name,
-			Capacity: bd.Spec.Capacity.Storage,
-			State:    bd.Status.State,
-		})
-	}
-
-	// Fetch info for provisional replica
-	CVRsInPool, err := clientset.GetCVRByPoolName(poolName)
-	if err != nil {
-		return errors.Wrap(err, "Error getting block device info")
-	}
-
-	var CVRInfoInPool []util.CVRInfo
-	for _, cvr := range CVRsInPool.Items {
-		CVRInfoInPool = append(CVRInfoInPool, util.CVRInfo{
-			Name:    cvr.Name,
-			PvcName: clientset.GetPVCNameByCVR(cvr.Labels["openebs.io/persistent-volume"]),
-			Size:    cvr.Status.Capacity.Total,
-			Status:  cvr.Status.Phase,
-		})
-	}
-
 	// Printing the filled details of the Pool
 	err = util.PrintByTemplate("pool", cStorPoolInstanceInfoTemplate, poolDetails)
 	if err != nil {
 		return err
 	}
 
-	for _, bd := range BdInfo {
-		err = util.PrintByTemplate("bd", blockDevicesInfoFromCSPI, bd)
+	// Fetch info for every block device
+	var bdRows []metav1.TableRow
+	for _, item := range BlockDevicesInPool {
+		bd, err := clientset.GetBlockDevice(item)
 		if err != nil {
-			return err
+			fmt.Printf("Could not find the blockdevice : %s\n", item)
+		}else{
+			bdRows = append(bdRows,  metav1.TableRow{Cells: []interface{}{bd.Name, humanize.IBytes(bd.Spec.Capacity.Storage), bd.Status.State}})
 		}
 	}
+	 if len(bdRows) != 0 {
+	 	fmt.Printf("Blockdevice details :\n" + "---------------------\n")
+		 util.TablePrinter(util.BDListColumnDefinations, bdRows, printers.PrintOptions{Wide: true})
+	 }else{
+		 fmt.Printf("Could not find any blockdevice that belongs to the pool")
+	 }
 
-	for _, cvr := range CVRInfoInPool {
-		err = util.PrintByTemplate("cvr", provisionedReplicasInfoFromCSPI, cvr)
-		if err != nil {
-			return err
+	// Fetch info for provisional replica
+	var cvrRows []metav1.TableRow
+	CVRsInPool, err := clientset.GetCVRByPoolName(poolName)
+	if err != nil {
+		fmt.Printf("None of the replicas are running")
+	}else{
+		for _, cvr := range CVRsInPool.Items {
+			cvrRows = append(cvrRows,  metav1.TableRow{Cells: []interface{}{
+				cvr.Name,
+				clientset.GetPVCNameByCVR(cvr.Labels["openebs.io/persistent-volume"]),
+				util.ConvertToIBytes(cvr.Status.Capacity.Total),
+				cvr.Status.Phase}})
 		}
 	}
-
+	if len(cvrRows) !=0 {
+		fmt.Printf("\nReplica Details :\n-----------------\n")
+		util.TablePrinter(util.PoolReplicaColumnDefinations, cvrRows, printers.PrintOptions{Wide: true})
+	}
 	return nil
 }

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -18,8 +18,9 @@ package describe
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 	"github.com/openebs/openebsctl/client"
@@ -79,7 +80,6 @@ STORAGE CLASS    : {{.StorageClassName}}
 SIZE             : {{.Size}}
 PV STATUS    	 : {{.PVStatus}}
 `
-
 )
 
 // NewCmdDescribePVC Displays the pvc describe details
@@ -197,7 +197,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 				if err == nil {
 					fmt.Printf("Target Details :\n----------------\n")
 					var rows []metav1.TableRow
-					rows = append(rows,  metav1.TableRow{Cells: []interface{}{targetPod.Namespace, targetPod.Name, util.GetReadyContainers(targetPod.Status.ContainerStatuses), targetPod.Status.Phase, util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)), targetPod.Status.PodIP, targetPod.Spec.NodeName}})
+					rows = append(rows, metav1.TableRow{Cells: []interface{}{targetPod.Namespace, targetPod.Name, util.GetReadyContainers(targetPod.Status.ContainerStatuses), targetPod.Status.Phase, util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)), targetPod.Status.PodIP, targetPod.Spec.NodeName}})
 					util.TablePrinter(util.CstorTargetDetailsColumnDefinations, rows, printers.PrintOptions{Wide: true})
 				} else {
 					fmt.Printf("Target Details :\n----------------\nNo target pod exists for the CstorVolume\n")

--- a/kubectl-openebs/cli/command/describe/pvc_info.go
+++ b/kubectl-openebs/cli/command/describe/pvc_info.go
@@ -18,6 +18,7 @@ package describe
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
@@ -25,6 +26,7 @@ import (
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/printers"
 )
 
 var (
@@ -42,45 +44,46 @@ $ kubectl openebs describe pvc [name1] [name2] ... [nameN] -n [namespace]
 const (
 	cstorPvcInfoTemplate = `
 {{.Name}} Details :
-Name             : {{.Name}}
-Namespace        : {{.Namespace}}
-Cas Type         : {{.CasType}}
-Bound Volume     : {{.BoundVolume}}
-Attached To Node : {{.AttachedToNode}}
-Pool             : {{.Pool}}
-Storage Class    : {{.StorageClassName}}
-Size             : {{.Size}}
-Used             : {{.Used}}
-PV Status	 : {{.PVStatus}}
+------------------
+NAME             : {{.Name}}
+NAMESPACE        : {{.Namespace}}
+CAS TYPE         : {{.CasType}}
+BOUND VOLUME     : {{.BoundVolume}}
+ATTACHED TO NODE : {{.AttachedToNode}}
+POOL             : {{.Pool}}
+STORAGE CLASS    : {{.StorageClassName}}
+SIZE             : {{.Size}}
+USED             : {{.Used}}
+PV STATUS	 : {{.PVStatus}}
 
 `
 
 	detailsFromCVC = `
 Additional Details from CVC :
-Name          : {{.Name}}
-Replica Count : {{.ReplicaCount}}
-Pool Info     : {{.PoolInfo}}
-Version       : {{.Version}}
-Upgrading     : {{.Upgrading}}
-
+-----------------------------
+NAME          : {{ .metadata.name }}
+REPLICA COUNT : {{ .spec.provision.replicaCount }}
+POOL INFO     : {{ .status.poolInfo}}
+VERSION       : {{ .versionDetails.status.current}}
+UPGRADING     : {{if eq .versionDetails.status.current .versionDetails.desired}}false{{else}}true{{end}}
 `
 
 	genericPvcInfoTemplate = `
 {{.Name}} Details :
-Name             : {{.Name}}
-Namespace        : {{.Namespace}}
-Cas Type         : {{.CasType}}
-Bound Volume     : {{.BoundVolume}}
-Storage Class    : {{.StorageClassName}}
-Size             : {{.Size}}
-PV Status	 : {{.PVStatus}}
-
+------------------
+NAME             : {{.Name}}
+NAMESPACE        : {{.Namespace}}
+CAS TYPE         : {{.CasType}}
+BOUND VOLUME     : {{.BoundVolume}}
+STORAGE CLASS    : {{.StorageClassName}}
+SIZE             : {{.Size}}
+PV STATUS    	 : {{.PVStatus}}
 `
+
 )
 
 // NewCmdDescribePVC Displays the pvc describe details
 func NewCmdDescribePVC() *cobra.Command {
-	var openebsNs string
 	cmd := &cobra.Command{
 		Use:     "pvc",
 		Aliases: []string{"pvcs", "persistentvolumeclaims", "persistentvolumeclaim"},
@@ -96,7 +99,6 @@ func NewCmdDescribePVC() *cobra.Command {
 			util.CheckErr(RunPVCInfo(cmd, args, pvNs, openebsNamespace), util.Fatal)
 		},
 	}
-	cmd.Flags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	return cmd
 }
 
@@ -110,9 +112,8 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 	// because the -n flag is used to take the pvc namespace and same cannot be used to
 	// take the openebs namespace
 	clientset, err := client.NewK8sClient(openebsNs)
-	if err != nil {
-		return errors.Wrap(err, "Failed to execute describe pvc command")
-	}
+	util.CheckErr(err, util.Fatal)
+
 	// Fetch the list of v1PVC objects by passing the name of PVCs taken through CLI in ns namespace
 	pvcList, err := clientset.GetPVCs(ns, pvcs)
 	// Incase the PVCs are not found no further operation to be performed
@@ -142,7 +143,6 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 				}
 				// Create Empty template objects and fill gradually when underlying sub CRs are identified.
 				pvcInfo := util.CstorPVCInfo{}
-				cvcInfo := util.CVCInfo{}
 
 				pvcInfo.Name = item.Name
 				pvcInfo.Namespace = item.Namespace
@@ -156,7 +156,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 				if err != nil {
 					fmt.Println("Underlying CstorVolume is not found for: ", item.Name)
 				} else {
-					pvcInfo.Size = cv.Spec.Capacity.String()
+					pvcInfo.Size = util.ConvertToIBytes(cv.Spec.Capacity.String())
 					pvcInfo.PVStatus = cv.Status.Phase
 				}
 
@@ -167,11 +167,6 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 					fmt.Println("Underlying CstorVolumeConfig is not found for: ", item.Name)
 				} else {
 					pvcInfo.Pool = cvc.Labels[cstortypes.CStorPoolClusterLabelKey]
-					cvcInfo.Name = cvc.Name
-					cvcInfo.ReplicaCount = len(cvc.Status.PoolInfo)
-					cvcInfo.PoolInfo = cvc.Status.PoolInfo
-					cvcInfo.Version = cvc.VersionDetails.Status.Current
-					cvcInfo.Upgrading = !(cvc.VersionDetails.Status.Current == cvc.VersionDetails.Desired)
 				}
 
 				// fetching the underlying CStorVolumeAttachment for the PV, to get the attached to node and notify the user
@@ -187,7 +182,7 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 				// none of the replicas are running if the CStorVolumeReplicas are not found.
 				cvrs, err := clientset.GetCVR(item.Spec.VolumeName)
 				if err == nil && len(cvrs.Items) > 0 {
-					pvcInfo.Used = util.GetUsedCapacityFromCVR(cvrs)
+					pvcInfo.Used = util.ConvertToIBytes(util.GetUsedCapacityFromCVR(cvrs))
 				}
 
 				// Printing the Filled Details of the Cstor PVC
@@ -200,49 +195,29 @@ func RunPVCInfo(cmd *cobra.Command, pvcs []string, ns string, openebsNs string) 
 				// if the TargetPod is not found.
 				targetPod, err := clientset.GetCstorVolumeTargetPod(item.Name, item.Spec.VolumeName)
 				if err == nil {
-					targetPodOutput := make([]string, 2)
-					fmt.Printf("Target Details :\n")
-					targetPodOutput[0] = "Namespace|Name|Ready|Status|Age|IP|Node"
-					targetPodOutput[1] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
-						targetPod.Namespace,
-						targetPod.Name,
-						util.GetReadyContainers(targetPod.Status.ContainerStatuses),
-						targetPod.Status.Phase,
-						util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)),
-						targetPod.Status.PodIP,
-						targetPod.Spec.NodeName,
-					)
-					fmt.Println(util.FormatList(targetPodOutput))
+					fmt.Printf("Target Details :\n----------------\n")
+					var rows []metav1.TableRow
+					rows = append(rows,  metav1.TableRow{Cells: []interface{}{targetPod.Namespace, targetPod.Name, util.GetReadyContainers(targetPod.Status.ContainerStatuses), targetPod.Status.Phase, util.Duration(time.Since(targetPod.ObjectMeta.CreationTimestamp.Time)), targetPod.Status.PodIP, targetPod.Spec.NodeName}})
+					util.TablePrinter(util.CstorTargetDetailsColumnDefinations, rows, printers.PrintOptions{Wide: true})
 				} else {
-					fmt.Println("Target Details :\nNo target pod exists for the CstorVolume")
+					fmt.Printf("Target Details :\n----------------\nNo target pod exists for the CstorVolume\n")
 				}
 
 				// If CVRs are found list them and show relevant details else notify the user none of the replicas are
 				// running if not found
 				if cvrs != nil && len(cvrs.Items) > 0 {
-					fmt.Printf("\nReplica Details :\n")
-					cvrOutput := make([]string, len(cvrs.Items)+1)
-					cvrOutput[0] = "Name|Total|Used|Status|Age"
-					for i, cvr := range cvrs.Items {
-						cvrOutput[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s",
-							cvr.Name,
-							cvr.Status.Capacity.Total,
-							cvr.Status.Capacity.Used,
-							cvr.Status.Phase,
-							util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time)),
-						)
+					fmt.Printf("\nReplica Details :\n-----------------\n")
+					var rows []metav1.TableRow
+					for _, cvr := range cvrs.Items {
+						rows = append(rows, metav1.TableRow{Cells: []interface{}{cvr.Name, util.ConvertToIBytes(cvr.Status.Capacity.Total), util.ConvertToIBytes(cvr.Status.Capacity.Used), cvr.Status.Phase, util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time))}})
 					}
-					fmt.Println(util.FormatList(cvrOutput))
+					util.TablePrinter(util.CstorReplicaColumnDefinations, rows, printers.PrintOptions{Wide: true})
 				} else {
-					fmt.Println("\nReplica Details :\nNo running replicas found")
+					fmt.Printf("\nReplica Details :\n-----------------\nNo running replicas found\n")
 				}
 
 				if cvc != nil {
-					// Printing the Filled Details of the CstorVolumeConfig
-					err = util.PrintByTemplate("cvc", detailsFromCVC, cvcInfo)
-					if err != nil {
-						return err
-					}
+					util.TemplatePrinter(detailsFromCVC, cvc)
 				}
 
 			} else {

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -18,7 +18,10 @@ package describe
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 	"os"
+	"time"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 
@@ -41,29 +44,29 @@ $ kubectl openebs describe [volume] [names...]
 
 const (
 	volInfoTemplate = `
-Volume Details :
-----------------
-Name            : {{.Name}}
-Access Mode     : {{.AccessMode}}
-CSI Driver      : {{.CSIDriver}}
-Storage Class   : {{.StorageClass}}
-Volume Phase    : {{.VolumePhase }}
-Version         : {{.Version}}
+{{.Name}} Details :
+-----------------
+NAME            : {{.Name}}
+ACCESS MODE     : {{.AccessMode}}
+CSI DRIVER      : {{.CSIDriver}}
+STORAGE CLASS   : {{.StorageClass}}
+VOLUME PHASE    : {{.VolumePhase }}
+VERSION         : {{.Version}}
 CSPC            : {{.CSPC}}
-Size            : {{.Size}}
-Status          : {{.Status}}
-ReplicaCount	: {{.ReplicaCount}}
+SIZE            : {{.Size}}
+STATUS          : {{.Status}}
+REPLICA COUNT	: {{.ReplicaCount}}
 
 `
 
 	portalTemplate = `
 Portal Details :
-----------------
-IQN             :  {{.IQN}}
-Volume          :  {{.VolumeName}}
-TargetNodeName  :  {{.TargetNodeName}}
-Portal          :  {{.Portal}}
-TargetIP        :  {{.TargetIP}}
+------------------
+IQN              :  {{.IQN}}
+VOLUME NAME      :  {{.VolumeName}}
+TARGET NODE NAME :  {{.TargetNodeName}}
+PORTAL           :  {{.Portal}}
+TARGET IP        :  {{.TargetIP}}
 
 `
 )
@@ -78,24 +81,27 @@ func NewCmdDescribeVolume() *cobra.Command {
 		Example: `kubectl openebs describe volume [vol]`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO: Get this from flags, pflag, etc
-			var ns string
-			if ns, _ = cmd.Flags().GetString("namespace"); ns == "" {
-				// NOTE: The error comes as nil even when the ns flag is not specified
-				ns = "openebs"
-			}
-			util.CheckErr(RunVolumeInfo(cmd, args, ns), util.Fatal)
+			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			util.CheckErr(RunVolumeInfo(cmd, args, openebsNs), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 // RunVolumeInfo runs info command and make call to DisplayVolumeInfo to display the results
-func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
+func RunVolumeInfo(cmd *cobra.Command, vols []string, openebsNs string) error {
 	// the stuff automatically coming from kubectl command execution
-	clientset, err := client.NewK8sClient(ns)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute volume info command")
+	clientset, err := client.NewK8sClient(openebsNs)
+	util.CheckErr(err, util.Fatal)
+
+	if openebsNs == "" {
+		nsFromCli, err := clientset.GetOpenEBSNamespace(util.CstorCasType)
+		if err != nil {
+			return errors.Wrap(err, "Error determining the openebs namespace, please specify using \"--openebs-namespace\" flag")
+		}
+		clientset.Ns = nsFromCli
 	}
+
 	// TODO: Print all volume info present in args or print all volume info if no args given
 	if len(vols) == 0 {
 		return errors.New("Please give at least one volume to describe")
@@ -151,7 +157,7 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 			VolumePhase:             pvInfo.Status.Phase,
 			StorageClass:            pvInfo.Spec.StorageClassName,
 			Version:                 util.CheckVersion(volumeInfo.VersionDetails),
-			Size:                    volumeInfo.Status.Capacity.String(),
+			Size:                    util.ConvertToIBytes(volumeInfo.Status.Capacity.String()),
 			Status:                  volumeInfo.Status.Phase,
 		}
 
@@ -179,24 +185,19 @@ func RunVolumeInfo(cmd *cobra.Command, vols []string, ns string) error {
 		// This case will occur only if user has manually specified zero replica.
 		// or if none of the replicas are healthy & running
 		if replicaCount == 0 || len(volumeInfo.Status.ReplicaStatuses) == 0 {
-			fmt.Fprint(os.Stderr, "None of the replicas are running")
+			fmt.Printf("None of the replicas are running\n")
 			//please check the volume pod's status by running [kubectl describe pvc -l=openebs/replica --all-namespaces]\Oor try again later.")
 			return nil
 		}
 
 		// Print replica details
 		if cvrInfo != nil && len(cvrInfo.Items) > 0 {
-			fmt.Printf("Replica Details :\n----------------\n")
-			out := make([]string, len(cvrInfo.Items)+2)
-			out[0] = "Name|Pool Instance|Status"
-			out[1] = "----|-------------|------"
-			for i, cvr := range cvrInfo.Items {
-				out[i+2] = fmt.Sprintf("%s|%s|%s",
-					cvr.ObjectMeta.Name,
-					cvr.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
-					cvr.Status.Phase)
+			fmt.Printf("\nReplica Details :\n-----------------\n")
+			var rows []metav1.TableRow
+			for _, cvr := range cvrInfo.Items {
+				rows = append(rows, metav1.TableRow{Cells: []interface{}{cvr.Name, util.ConvertToIBytes(cvr.Status.Capacity.Total), util.ConvertToIBytes(cvr.Status.Capacity.Used), cvr.Status.Phase, util.Duration(time.Since(cvr.ObjectMeta.CreationTimestamp.Time))}})
 			}
-			fmt.Println(util.FormatList(out))
+			util.TablePrinter(util.CstorReplicaColumnDefinations, rows, printers.PrintOptions{Wide: true})
 		}
 		fmt.Println()
 	}

--- a/kubectl-openebs/cli/command/describe/volume_info.go
+++ b/kubectl-openebs/cli/command/describe/volume_info.go
@@ -18,10 +18,11 @@ package describe
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/printers"
 	"os"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 
@@ -81,7 +82,7 @@ func NewCmdDescribeVolume() *cobra.Command {
 		Example: `kubectl openebs describe volume [vol]`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO: Get this from flags, pflag, etc
-			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
 			util.CheckErr(RunVolumeInfo(cmd, args, openebsNs), util.Fatal)
 		},
 	}

--- a/kubectl-openebs/cli/command/get/pool_list.go
+++ b/kubectl-openebs/cli/command/get/pool_list.go
@@ -18,9 +18,10 @@ package get
 
 import (
 	"fmt"
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
-	"time"
 
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/openebsctl/client"
@@ -46,7 +47,7 @@ func NewCmdGetPool() *cobra.Command {
 		Short:   "Displays status information about Pool(s)",
 		Long:    poolListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
 			// TODO: De-couple CLI code, logic code, API code
 			util.CheckErr(RunPoolsList(cmd, args, openebsNs), util.Fatal)
 		},
@@ -91,7 +92,7 @@ func RunPoolsList(cmd *cobra.Command, pools []string, openebsNs string) error {
 	}
 	if len(cpools.Items) == 0 {
 		fmt.Println("No Pools are found")
-	}else{
+	} else {
 		util.TablePrinter(util.CstorPoolListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	}
 	return nil

--- a/kubectl-openebs/cli/command/get/pool_list.go
+++ b/kubectl-openebs/cli/command/get/pool_list.go
@@ -18,6 +18,8 @@ package get
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 	"time"
 
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
@@ -32,7 +34,7 @@ var (
 This command lists of all known pools in the Cluster.
 
 Usage:
-$ kubectl openebs get pool [options]
+$ kubectl openebs get pools [options]
 `
 )
 
@@ -44,52 +46,53 @@ func NewCmdGetPool() *cobra.Command {
 		Short:   "Displays status information about Pool(s)",
 		Long:    poolListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			ns, err := cmd.Flags().GetString("namespace")
-			if err != nil {
-				ns = "openebs"
-			}
+			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
 			// TODO: De-couple CLI code, logic code, API code
-			util.CheckErr(RunPoolsList(cmd, args, ns), util.Fatal)
+			util.CheckErr(RunPoolsList(cmd, args, openebsNs), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 //RunPoolsList fetchs & lists the pools
-func RunPoolsList(cmd *cobra.Command, pools []string, ns string) error {
-	client, err := client.NewK8sClient(ns)
+func RunPoolsList(cmd *cobra.Command, pools []string, openebsNs string) error {
+	k8sClient, err := client.NewK8sClient(openebsNs)
 	util.CheckErr(err, util.Fatal)
+	if openebsNs == "" {
+		nsFromCli, err := k8sClient.GetOpenEBSNamespace(util.CstorCasType)
+		if err != nil {
+			return errors.Wrap(err, "Error determining the openebs namespace, please specify using \"--openebs-namespace\" flag")
+		}
+		k8sClient.Ns = nsFromCli
+	}
 	var cpools *v1.CStorPoolInstanceList
 	if len(pools) == 0 {
 		// List all
-		cpools, err = client.GetcStorPools()
+		cpools, err = k8sClient.GetcStorPools()
 	} else {
 		// Get one or more
-		cpools, err = client.GetcStorPoolsByName(pools)
+		cpools, err = k8sClient.GetcStorPoolsByName(pools)
 	}
 	if err != nil {
 		return errors.Wrap(err, "error listing pools")
 	}
-	out := make([]string, len(cpools.Items)+2)
-	out[0] = "Name|HostName|Free|Capacity|ReadOnly|ProvisionedReplicas|HealthyReplicas|Status|Age"
-	out[1] = "----|--------|----|--------|--------|-------------------|---------------|------|---"
-	for i, item := range cpools.Items {
-		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%v|%d|%d|%s|%s",
+	var rows []metav1.TableRow
+	for _, item := range cpools.Items {
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{
 			item.ObjectMeta.Name,
 			item.ObjectMeta.Labels["kubernetes.io/hostname"],
-			item.Status.Capacity.Free.String(),
-			item.Status.Capacity.Total.String(),
+			util.ConvertToIBytes(item.Status.Capacity.Free.String()),
+			util.ConvertToIBytes(item.Status.Capacity.Total.String()),
 			item.Status.ReadOnly,
 			item.Status.ProvisionedReplicas,
 			item.Status.HealthyReplicas,
 			item.Status.Phase,
-			util.Duration(time.Since(item.ObjectMeta.CreationTimestamp.Time)),
-		)
-		if len(out) == 2 {
-			fmt.Println("No Pools are found")
-			return nil
-		}
+			util.Duration(time.Since(item.ObjectMeta.CreationTimestamp.Time))}})
 	}
-	fmt.Println(util.FormatList(out))
+	if len(cpools.Items) == 0 {
+		fmt.Println("No Pools are found")
+	}else{
+		util.TablePrinter(util.CstorPoolListColumnDefinations, rows, printers.PrintOptions{Wide: true})
+	}
 	return nil
 }

--- a/kubectl-openebs/cli/command/get/volume_list.go
+++ b/kubectl-openebs/cli/command/get/volume_list.go
@@ -44,7 +44,7 @@ func NewCmdGetVolume() *cobra.Command {
 		Short:   "Displays status information about Volume(s)",
 		Long:    volumesListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
 			util.CheckErr(RunVolumesList(cmd, openebsNs, args), util.Fatal)
 		},
 	}
@@ -52,7 +52,7 @@ func NewCmdGetVolume() *cobra.Command {
 }
 
 // RunVolumesList lists the volumes
-func RunVolumesList(cmd *cobra.Command,openebsNs string, vols []string) error {
+func RunVolumesList(cmd *cobra.Command, openebsNs string, vols []string) error {
 	k8sClient, err := client.NewK8sClient("")
 	util.CheckErr(err, util.Fatal)
 	if openebsNs == "" {
@@ -79,7 +79,7 @@ func RunVolumesList(cmd *cobra.Command,openebsNs string, vols []string) error {
 	// give output according to volume status
 	var rows []metav1.TableRow
 	for _, item := range cvols.Items {
-		rows = append(rows,  metav1.TableRow{Cells: []interface{}{
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{
 			item.ObjectMeta.Namespace,
 			item.ObjectMeta.Name,
 			item.Status.Phase,

--- a/kubectl-openebs/cli/command/get/volume_list.go
+++ b/kubectl-openebs/cli/command/get/volume_list.go
@@ -17,7 +17,8 @@ limitations under the License.
 package get
 
 import (
-	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
 
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/openebsctl/client"
@@ -31,7 +32,7 @@ var (
 This command displays status of available zfs Volumes.
 If no volume ID is given, a list of all known volumes will be displayed.
 
-Usage: kubectl openebs cStor volume list [options]
+Usage: kubectl openebs get volume [options]
 `
 )
 
@@ -43,53 +44,54 @@ func NewCmdGetVolume() *cobra.Command {
 		Short:   "Displays status information about Volume(s)",
 		Long:    volumesListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
-			util.CheckErr(RunVolumesList(cmd, args), util.Fatal)
+			openebsNs,_ := cmd.Flags().GetString("openebs-namespace")
+			util.CheckErr(RunVolumesList(cmd, openebsNs, args), util.Fatal)
 		},
 	}
 	return cmd
 }
 
 // RunVolumesList lists the volumes
-func RunVolumesList(cmd *cobra.Command, vols []string) error {
-	client, err := client.NewK8sClient("")
+func RunVolumesList(cmd *cobra.Command,openebsNs string, vols []string) error {
+	k8sClient, err := client.NewK8sClient("")
 	util.CheckErr(err, util.Fatal)
+	if openebsNs == "" {
+		nsFromCli, err := k8sClient.GetOpenEBSNamespace(util.CstorCasType)
+		if err != nil {
+			return errors.Wrap(err, "Error determining the openebs namespace, please specify using \"--openebs-namespace\" flag")
+		}
+		k8sClient.Ns = nsFromCli
+	}
 	var cvols *v1.CStorVolumeList
 	if len(vols) == 0 {
-		cvols, err = client.GetcStorVolumes()
+		cvols, err = k8sClient.GetcStorVolumes()
 	} else {
-		cvols, err = client.GetcStorVolumesByNames(vols)
+		cvols, err = k8sClient.GetcStorVolumesByNames(vols)
 	}
 	if err != nil {
 		return errors.Wrap(err, "error listing volumes")
 	}
-	pvols, err := client.GetCStorVolumeInfoMap("")
+	pvols, err := k8sClient.GetCStorVolumeInfoMap("")
 	if err != nil {
 		return errors.Wrap(err, "failed to execute volume info command")
 	}
 	// tally status of cvols to pvols
 	// give output according to volume status
-	out := make([]string, len(cvols.Items)+2)
-	out[0] = "Namespace|Name|Status|Version|Capacity|StorageClass|Attached|Access Mode|Attached Node"
-	out[1] = "---------|----|------|-------|--------|------------|--------|-----------|-------------"
-	for i, item := range cvols.Items {
-		pvols[item.ObjectMeta.Name] = util.CheckForVol(item.ObjectMeta.Name, pvols)
-		out[i+2] = fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s|%s|%s",
+	var rows []metav1.TableRow
+	for _, item := range cvols.Items {
+		rows = append(rows,  metav1.TableRow{Cells: []interface{}{
 			item.ObjectMeta.Namespace,
 			item.ObjectMeta.Name,
 			item.Status.Phase,
 			item.VersionDetails.Status.Current,
-			item.Status.Capacity.String(),
+			util.ConvertToIBytes(item.Status.Capacity.String()),
 			pvols[item.ObjectMeta.Name].StorageClass,
 			pvols[item.ObjectMeta.Name].AttachementStatus,
 			pvols[item.ObjectMeta.Name].AccessMode,
-			pvols[item.ObjectMeta.Name].Node)
+			pvols[item.ObjectMeta.Name].Node}})
 		//TODO: find a fix
 		//pvols[item.ObjectMeta.Name].CSIVolumeAttachmentName field removed for readability
 	}
-	if len(out) == 2 {
-		fmt.Println("No Volumes are running")
-		return nil
-	}
-	fmt.Println(util.FormatList(out))
+	util.TablePrinter(util.CstorVolumeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }

--- a/kubectl-openebs/cli/util/constant.go
+++ b/kubectl-openebs/cli/util/constant.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package util
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 const (
 	// BytesToGB used to convert bytes to GB
 	BytesToGB = 1073741824
@@ -57,5 +59,60 @@ var (
 		"openebs.io/local":             "local",
 		"local.csi.openebs.io ":        "localpv-lvm",
 		"zfs.csi.openebs.io":           "localpv-zfs",
+	}
+	// CstorReplicaColumnDefinations stores the Table headers for CVR Details
+	CstorReplicaColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Total", Type: "string"},
+		{Name: "Used", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
+	// CstorTargetDetailsColumnDefinations stores the Table headers for Cstor Target Details
+	CstorTargetDetailsColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Namespace", Type: "string"},
+		{Name: "Name", Type: "string"},
+		{Name: "Ready", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "Age", Type: "string"},
+		{Name: "IP", Type: "string"},
+		{Name: "Node", Type: "string"},
+	}
+	// CstorVolumeListColumnDefinations stores the Table headers for Cstor Volume Details
+	CstorVolumeListColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Namespace", Type: "string"},
+		{Name: "Name", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "Version", Type: "string"},
+		{Name: "Capacity", Type: "string"},
+		{Name: "Storage Class", Type: "string"},
+		{Name: "Attached", Type: "string"},
+		{Name: "Access Mode", Type: "string"},
+		{Name: "Attached Node", Type: "string"},
+	}
+	// CstorPoolListColumnDefinations stores the Table headers for Cstor Pool Details
+	CstorPoolListColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "HostName", Type: "string"},
+		{Name: "Free", Type: "string"},
+		{Name: "Capacity", Type: "string"},
+		{Name: "Read Only", Type: "bool"},
+		{Name: "Provisioned Replicas", Type: "int"},
+		{Name: "Healthy Replicas", Type: "int"},
+		{Name: "Status", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
+	// BDListColumnDefinations stores the Table headers for Block Device Details
+	BDListColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Capacity", Type: "string"},
+		{Name: "State", Type: "string"},
+	}
+	// PoolReplicaColumnDefinations stores the Table headers for Pool Replica Details
+	PoolReplicaColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "PVC Name", Type: "string"},
+		{Name: "Size", Type: "string"},
+		{Name: "State", Type: "string"},
 	}
 )

--- a/kubectl-openebs/cli/util/types.go
+++ b/kubectl-openebs/cli/util/types.go
@@ -125,16 +125,6 @@ type CstorPVCInfo struct {
 	PVStatus         v1.CStorVolumePhase
 }
 
-// CVCInfo struct will have all the details we want to give in the output for describe pvc
-// cvc section for cstor pvc
-type CVCInfo struct {
-	Name         string
-	ReplicaCount int
-	PoolInfo     []string
-	Version      string
-	Upgrading    bool
-}
-
 // PVCInfo struct will have all the details we want to give in the output for describe pvc
 // details section for non-cstor pvc
 type PVCInfo struct {

--- a/kubectl-openebs/cli/util/util.go
+++ b/kubectl-openebs/cli/util/util.go
@@ -19,15 +19,16 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"html/template"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/printers"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/dustin/go-humanize"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/printers"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog"
@@ -113,7 +114,7 @@ func TemplatePrinter(template string, obj runtime.Object) {
 }
 
 // ConvertToIBytes humanizes all the passed units to IBytes format
-func ConvertToIBytes(value string) string{
+func ConvertToIBytes(value string) string {
 	if value == "" {
 		return value
 	}

--- a/kubectl-openebs/cli/util/util_test.go
+++ b/kubectl-openebs/cli/util/util_test.go
@@ -69,3 +69,72 @@ func TestDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToIBytes(t *testing.T) {
+	type args struct {
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"Test with GB values",
+			args{value: "1.65GB"},
+			"1.5 GiB",
+		},
+		{
+			"Test with MB values",
+			args{value: "1.65MB"},
+			"1.6 MiB",
+		},
+		{
+			"Test with KB values",
+			args{value: "1.65KB"},
+			"1.6 KiB",
+		},
+		{
+			"Test with K values",
+			args{value: "1.65K"},
+			"1.6 KiB",
+		},
+		{
+			"Test with M values",
+			args{value: "1.65M"},
+			"1.6 MiB",
+		},
+		{
+			"Test with MiB values",
+			args{value: "1.65MiB"},
+			"1.6 MiB",
+		},
+		{
+			"Test with Mi values",
+			args{value: "1.65Mi"},
+			"1.6 MiB",
+		},
+		{
+			"Test with invalid",
+			args{value: ""},
+			"",
+		},
+		{
+			"Test with only numeric value",
+			args{value: "1766215"},
+			"1.7 MiB",
+		},
+		{
+			"Test with only invalid unit",
+			args{value: "1766215CiB"},
+			"1766215CiB",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConvertToIBytes(tt.args.value); got != tt.want {
+				t.Errorf("Duration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- This PR adds cli-runtime `TablePrinters`, `TemplatePrinters` for printing the command outputs similar to the `Kubectl` outputs.
- This PR adds a `PersistentFlag` `--openebs-namespace` for taking `openebs`  namespace from user if cli fails to determine the `openebs ns`. Earlier we were using `-n` commands for the same but `-n` command is meant for resource namespace, so to remove confusion this dedicated flag is added for `openebs` namespace.
- This PR adds the logic for determining `openebs` ns to all the available commands, earlier it was only for ` pvc describe` command only.
- This PR adds a adds the logic to show all size units in the same `humanized` format and Unit tests for the same.
- Minor bug fixes.
- Closed #24 

Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>