### PR TITLE
Add version sub-command to show client-version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     goos: ['linux', 'darwin', 'windows']
     goarch: ['386', 'amd64', 'arm64']
     ldflags:
-      - -s -w -X github.com/openebs/openebsctl/kubectl-openebs/cli/command.Version={{ .Tag }}
+      - "-X 'github.com/openebs/openebsctl/kubectl-openebs/cli/command.Version={{ .Tag }}'"
 
 changelog:
   sort: 'asc'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,8 @@ builds:
       - CGO_ENABLED=0
     goos: ['linux', 'darwin', 'windows']
     goarch: ['386', 'amd64', 'arm64']
-  # TODO: Add ldflags after version changes are added
+    ldflags:
+      - -s -w -X github.com/openebs/openebsctl/kubectl-openebs/cli/command.Version={{ .Tag }}
 
 changelog:
   sort: 'asc'

--- a/kubectl-openebs/cli/command/commands.go
+++ b/kubectl-openebs/cli/command/commands.go
@@ -21,11 +21,15 @@ import (
 
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/command/describe"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/command/get"
+	v "github.com/openebs/openebsctl/kubectl-openebs/cli/command/version"
 	"github.com/openebs/openebsctl/kubectl-openebs/cli/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
+
+// version is the version of the openebsctl binary, info filled by goreleaser
+var version = "dev"
 
 // NewOpenebsCommand creates the `openebs` command and its nested children.
 func NewOpenebsCommand() *cobra.Command {
@@ -35,6 +39,7 @@ func NewOpenebsCommand() *cobra.Command {
 		Short: "openebs is a a kubectl plugin for interacting with OpenEBS storage components",
 		Long: `openebs is a a kubectl plugin for interacting with OpenEBS storage components
 Find out more about OpenEBS on https://docs.openebs.io/`,
+		Version: version,
 		// Version: show the version of this plugin
 	}
 	// TODO: Check if this brings in the flags from kubectl binary to this one via exec for all platforms
@@ -46,6 +51,7 @@ Find out more about OpenEBS on https://docs.openebs.io/`,
 		util.NewCmdCompletion(cmd),
 		get.NewCmdGet(cmd),
 		describe.NewCmdDescribe(cmd),
+		v.NewCmdVersion(cmd),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)

--- a/kubectl-openebs/cli/command/commands.go
+++ b/kubectl-openebs/cli/command/commands.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-// version is the version of the openebsctl binary, info filled by goreleaser
-var version = "dev"
+// Version is the version of the openebsctl binary, info filled by goreleaser
+var Version = "dev"
 
 // NewOpenebsCommand creates the `openebs` command and its nested children.
 func NewOpenebsCommand() *cobra.Command {
@@ -39,8 +39,7 @@ func NewOpenebsCommand() *cobra.Command {
 		Short: "openebs is a a kubectl plugin for interacting with OpenEBS storage components",
 		Long: `openebs is a a kubectl plugin for interacting with OpenEBS storage components
 Find out more about OpenEBS on https://docs.openebs.io/`,
-		Version: version,
-		// Version: show the version of this plugin
+		Version: Version,
 	}
 	// TODO: Check if this brings in the flags from kubectl binary to this one via exec for all platforms
 	kubernetesConfigFlags := genericclioptions.NewConfigFlags(true)

--- a/kubectl-openebs/cli/command/version/version.go
+++ b/kubectl-openebs/cli/command/version/version.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdVersion shows OpenEBS version
+func NewCmdVersion(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show client version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("Client Version: " + rootCmd.Version)
+		},
+	}
+	return cmd
+}

--- a/kubectl-openebs/cli/command/version/version.go
+++ b/kubectl-openebs/cli/command/version/version.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdVersion shows OpenEBS version
+// NewCmdVersion shows OpenEBSCTL version
 func NewCmdVersion(rootCmd *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",


### PR DESCRIPTION
# Output examples

```bash
$ ▶ kubectl openebs 
openebs is a a kubectl plugin for interacting with OpenEBS storage components
Find out more about OpenEBS on https://docs.openebs.io/

Usage:
  openebs [command]

Available Commands:
  completion  Outputs shell completion code for the specified shell (bash or zsh)
  describe    Provide detailed information about an OpenEBS resource
  get         Provides operations related to a Volume
  help        Help about any command
  version     Show client version
```

```bash
# Overwrite dev with `123` for example
harsh @ brahmastra ~/.../github.com/openebs/openebsctl (relver)
└─ $ ▶ go build -ldflags="-X 'github.com/openebs/openebsctl/kubectl-openebs/cli/command.Version=123'" -o ~/bin/kubectl-openebs kubectl-openebs/main.go 
harsh @ brahmastra ~/.../github.com/openebs/openebsctl (relver)
└─ $ ▶ kubectl openebs version
Client Version: 123
```

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>