### PR TITLE
feat(bd listing): Add bd listing to show bd by node, unit tests for blockdevice package.

### DIFF
--- a/cmd/get/blockdevice.go
+++ b/cmd/get/blockdevice.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"github.com/openebs/openebsctl/pkg/blockdevice"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	bdListCommandHelpText = `
+This command displays status of available OpenEBS blockdevices.
+
+Usage: kubectl openebs get bd [options]
+
+Advanced:
+Filter by a fixed OpenEBS namespace
+--openebs-namespace=[...]
+`
+)
+
+// NewCmdGetBD displays status of OpenEBS BlockDevice(s)
+func NewCmdGetBD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "bd",
+		Aliases: []string{"bds", "blockdevice", "blockdevices"},
+		Short:   "Displays status information about BlockDevices",
+		Long:    bdListCommandHelpText,
+		Run: func(cmd *cobra.Command, args []string) {
+			// TODO: Should this method create the k8sClient object
+			openebsNS, _ := cmd.Flags().GetString("openebs-namespace")
+			util.CheckErr(blockdevice.Get(args, openebsNS), util.Fatal)
+		},
+	}
+	return cmd
+}

--- a/cmd/get/blockdevice.go
+++ b/cmd/get/blockdevice.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	bdListCommandHelpText = `
-This command displays status of available OpenEBS blockdevices.
+This command displays status of available OpenEBS BlockDevice(s).
 
 Usage: kubectl openebs get bd [options]
 
@@ -39,7 +39,7 @@ func NewCmdGetBD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bd",
 		Aliases: []string{"bds", "blockdevice", "blockdevices"},
-		Short:   "Displays status information about BlockDevices",
+		Short:   "Displays status information about BlockDevice(s)",
 		Long:    bdListCommandHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
 			// TODO: Should this method create the k8sClient object

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -23,15 +23,18 @@ import (
 )
 
 const (
-	getCmdHelp = `Display one or many OpenEBS resources like volumes, pools
+	getCmdHelp = `Display one or many OpenEBS resources like volumes, pools, blockdevices
 
-$ kubectl openebs get [volumes|pools] [-n example-namespace]
+$ kubectl openebs get [volumes|pools|bds] [flags]
 
 # Get volumes
 $ kubectl openebs get volume
 
 # Get pools
 $ kubectl openebs get pool
+
+# Get blockdevices
+$ kubectl openebs get bd
 `
 )
 

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -51,6 +51,7 @@ func NewCmdGet(rootCmd *cobra.Command) *cobra.Command {
 	cmd.AddCommand(
 		NewCmdGetVolume(),
 		NewCmdGetPool(),
+		NewCmdGetBD(),
 	)
 	return cmd
 }

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -66,42 +66,41 @@ func createTreeByNode(k *client.K8sClient, bds []string) error {
 	if len(nodeBDlistMap) == 0 {
 		// If there are no block devices show error
 		return errors.New("no blockdevices found in the " + k.Ns + " namespace")
-	} else {
-		for key, value := range nodeBDlistMap {
-			// Create the root, which contains only the node-name
-			rows = append(rows, metav1.TableRow{Cells: []interface{}{key, "", "", "", "", "", ""}})
-			for i, bd := range value {
-				// If the bd is the last bd in the list, or the list has only one bd
-				// append lastElementPrefix before bd name
-				if i == len(value)-1 {
-					rows = append(rows, metav1.TableRow{
-						Cells: []interface{}{
-							lastElemPrefix + bd.Name,
-							bd.Spec.Path,
-							humanize.IBytes(bd.Spec.Capacity.Storage),
-							bd.Status.ClaimState,
-							bd.Status.State,
-							bd.Spec.FileSystem.Type,
-							bd.Spec.FileSystem.Mountpoint,
-						}})
-				} else {
-					// If the bd is the not last bd in the list append firstElementPrefix before
-					// bd name which signifies there are more to append in the tree.
-					rows = append(rows, metav1.TableRow{
-						Cells: []interface{}{
-							firstElemPrefix + bd.Name,
-							bd.Spec.Path,
-							humanize.IBytes(bd.Spec.Capacity.Storage),
-							bd.Status.ClaimState,
-							bd.Status.State,
-							bd.Spec.FileSystem.Type,
-							bd.Spec.FileSystem.Mountpoint,
-						}})
-				}
+	}
+	for key, value := range nodeBDlistMap {
+		// Create the root, which contains only the node-name
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{key, "", "", "", "", "", ""}})
+		for i, bd := range value {
+			// If the bd is the last bd in the list, or the list has only one bd
+			// append lastElementPrefix before bd name
+			if i == len(value)-1 {
+				rows = append(rows, metav1.TableRow{
+					Cells: []interface{}{
+						lastElemPrefix + bd.Name,
+						bd.Spec.Path,
+						humanize.IBytes(bd.Spec.Capacity.Storage),
+						bd.Status.ClaimState,
+						bd.Status.State,
+						bd.Spec.FileSystem.Type,
+						bd.Spec.FileSystem.Mountpoint,
+					}})
+			} else {
+				// If the bd is the not last bd in the list append firstElementPrefix before
+				// bd name which signifies there are more to append in the tree.
+				rows = append(rows, metav1.TableRow{
+					Cells: []interface{}{
+						firstElemPrefix + bd.Name,
+						bd.Spec.Path,
+						humanize.IBytes(bd.Spec.Capacity.Storage),
+						bd.Status.ClaimState,
+						bd.Status.State,
+						bd.Spec.FileSystem.Type,
+						bd.Spec.FileSystem.Mountpoint,
+					}})
 			}
-			// Add an empty row so that the tree looks neat
-			rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", "", "", "", "", ""}})
 		}
+		// Add an empty row so that the tree looks neat
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", "", "", "", "", ""}})
 	}
 	// Show the output using cli-runtime
 	util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -17,29 +17,93 @@ limitations under the License.
 package blockdevice
 
 import (
-	"fmt"
+	"github.com/dustin/go-humanize"
 	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+const (
+	firstElemPrefix = `├─`
+	lastElemPrefix  = `└─`
 )
 
 // Get manages various implementations of blockdevice listing
 func Get(bds []string, openebsNS string) error {
 	// TODO: Prefer passing the client from outside
-	k, _ := client.NewK8sClient("")
-	// 1. Get a list of all BlockDevices
-	var bdList *v1alpha1.BlockDeviceList
-	bdList, err := k.GetBDs(bds,"")
+	k, _ := client.NewK8sClient(openebsNS)
+	err := createTreeByNode(k, bds)
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// createTreeByNode uses the [node <- list of bds on the node] and creates a tree like output,
+// also showing the relevant details to the bds.
+func createTreeByNode(k *client.K8sClient, bds []string) error {
+	// 1. Get a list of the BlockDevices
+	var bdList *v1alpha1.BlockDeviceList
+	bdList, err := k.GetBDs(bds, "")
+	if err != nil {
+		return err
+	}
+	// 2. Create a map out of the list of bds, by their node names.
 	var nodeBDlistMap = map[string][]v1alpha1.BlockDevice{}
 	for _, bd := range bdList.Items {
 		if _, ok := nodeBDlistMap[bd.Spec.NodeAttributes.NodeName]; ok {
+			// Append to the node if key exists
 			nodeBDlistMap[bd.Spec.NodeAttributes.NodeName] = append(nodeBDlistMap[bd.Spec.NodeAttributes.NodeName], bd)
-		}else{
+		} else {
+			// Create new key with node name and add the bd, if node does not exist
 			nodeBDlistMap[bd.Spec.NodeAttributes.NodeName] = []v1alpha1.BlockDevice{bd}
 		}
 	}
-	fmt.Println(nodeBDlistMap)
+	var rows []metav1.TableRow
+	if len(nodeBDlistMap) == 0 {
+		// If there are no block devices show error
+		return errors.New("no blockdevices found in the " + k.Ns + " namespace")
+	} else {
+		for key, value := range nodeBDlistMap {
+			// Create the root, which contains only the node-name
+			rows = append(rows, metav1.TableRow{Cells: []interface{}{key, "", "", "", "", "", ""}})
+			for i, bd := range value {
+				// If the bd is the last bd in the list, or the list has only one bd
+				// append lastElementPrefix before bd name
+				if i == len(value)-1 {
+					rows = append(rows, metav1.TableRow{
+						Cells: []interface{}{
+							lastElemPrefix + bd.Name,
+							bd.Spec.Path,
+							humanize.IBytes(bd.Spec.Capacity.Storage),
+							bd.Status.ClaimState,
+							bd.Status.State,
+							bd.Spec.FileSystem.Type,
+							bd.Spec.FileSystem.Mountpoint,
+						}})
+				} else {
+					// If the bd is the not last bd in the list append firstElementPrefix before
+					// bd name which signifies there are more to append in the tree.
+					rows = append(rows, metav1.TableRow{
+						Cells: []interface{}{
+							firstElemPrefix + bd.Name,
+							bd.Spec.Path,
+							humanize.IBytes(bd.Spec.Capacity.Storage),
+							bd.Status.ClaimState,
+							bd.Status.State,
+							bd.Spec.FileSystem.Type,
+							bd.Spec.FileSystem.Mountpoint,
+						}})
+				}
+			}
+			// Add an empty row so that the tree looks neat
+			rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", "", "", "", "", ""}})
+		}
+	}
+	// Show the output using cli-runtime
+	util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockdevice
+
+import (
+	"fmt"
+	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/openebsctl/pkg/client"
+)
+
+// Get manages various implementations of blockdevice listing
+func Get(bds []string, openebsNS string) error {
+	// TODO: Prefer passing the client from outside
+	k, _ := client.NewK8sClient("")
+	// 1. Get a list of all BlockDevices
+	var bdList *v1alpha1.BlockDeviceList
+	bdList, err := k.GetBDs(bds,"")
+	if err != nil {
+		return err
+	}
+	var nodeBDlistMap = map[string][]v1alpha1.BlockDevice{}
+	for _, bd := range bdList.Items {
+		if _, ok := nodeBDlistMap[bd.Spec.NodeAttributes.NodeName]; ok {
+			nodeBDlistMap[bd.Spec.NodeAttributes.NodeName] = append(nodeBDlistMap[bd.Spec.NodeAttributes.NodeName], bd)
+		}else{
+			nodeBDlistMap[bd.Spec.NodeAttributes.NodeName] = []v1alpha1.BlockDevice{bd}
+		}
+	}
+	fmt.Println(nodeBDlistMap)
+	return nil
+}

--- a/pkg/blockdevice/blockdevice_test.go
+++ b/pkg/blockdevice/blockdevice_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package blockdevice
 
 import (

--- a/pkg/blockdevice/blockdevice_test.go
+++ b/pkg/blockdevice/blockdevice_test.go
@@ -1,0 +1,247 @@
+package blockdevice
+
+import (
+	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	openebsFakeClientset "github.com/openebs/api/v2/pkg/client/clientset/versioned/fake"
+	"github.com/openebs/openebsctl/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+var (
+	bd1 = v1alpha1.BlockDevice{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "some-fake-bd-1"},
+		Spec: v1alpha1.DeviceSpec{
+			Path:     "/dev/sdb",
+			Capacity: v1alpha1.DeviceCapacity{Storage: uint64(132131321)},
+			FileSystem: v1alpha1.FileSystemInfo{
+				Type:       "zfs_member",
+				Mountpoint: "/var/some-fake-point",
+			},
+			NodeAttributes: v1alpha1.NodeAttribute{
+				NodeName: "fake-node-1",
+			},
+		},
+		Status: v1alpha1.DeviceStatus{
+			ClaimState: "Claimed",
+			State:      "Active",
+		},
+	}
+	bd2 = v1alpha1.BlockDevice{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "some-fake-bd-2"},
+		Spec: v1alpha1.DeviceSpec{
+			Path:     "/dev/sdb",
+			Capacity: v1alpha1.DeviceCapacity{Storage: uint64(132131321)},
+			FileSystem: v1alpha1.FileSystemInfo{
+				Type:       "zfs_member",
+				Mountpoint: "/var/some-fake-point",
+			},
+			NodeAttributes: v1alpha1.NodeAttribute{
+				NodeName: "fake-node-1",
+			},
+		},
+		Status: v1alpha1.DeviceStatus{
+			ClaimState: "Claimed",
+			State:      "Active",
+		},
+	}
+	bd3 = v1alpha1.BlockDevice{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Name: "some-fake-bd-3",Namespace: "fake-ns"},
+		Spec: v1alpha1.DeviceSpec{
+			Path:     "/dev/sdb",
+			Capacity: v1alpha1.DeviceCapacity{Storage: uint64(132131321)},
+			FileSystem: v1alpha1.FileSystemInfo{
+				Type:       "lvm_member",
+				Mountpoint: "/var/some-fake-point",
+			},
+			NodeAttributes: v1alpha1.NodeAttribute{
+				NodeName: "fake-node-2",
+			},
+		},
+		Status: v1alpha1.DeviceStatus{
+			ClaimState: "Claimed",
+			State:      "Active",
+		},
+	}
+)
+
+func Test_createTreeByNode(t *testing.T) {
+	k8sCS := fake.NewSimpleClientset()
+	type args struct {
+		k   *client.K8sClient
+		bds []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"Test with valid bd inputs and across all namespaces",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: nil,
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs and in some valid ns",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: nil,
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs and in some invalid ns",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-invalid-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: nil,
+			},
+			true,
+		},
+		{
+			"Test with invalid bd inputs and in some valid ns",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(),
+				},
+				bds: nil,
+			},
+			true,
+		},
+		{
+			"Test with invalid bd inputs across all namespaces",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(),
+				},
+				bds: nil,
+			},
+			true,
+		},
+		{
+			"Test with valid bd inputs across all namespaces with some valid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-3"},
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs across all namespaces with multiple valid bd names passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-3", "some-fake-bd-2"},
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs across all namespaces with some valid and some invalid bd names passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-365", "some-fake-bd-2"},
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs across all namespaces with some invalid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-365"},
+			},
+			true,
+		},
+		{
+			"Test with valid bd inputs in a namespace with some valid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-3"},
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs in an invalid namespace with some valid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-invalid-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-3"},
+			},
+			true,
+		},
+		{
+			"Test with valid bd inputs in a valid namespace with some valid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-3"},
+			},
+			false,
+		},
+		{
+			"Test with valid bd inputs in a valid namespace with some invalid bd name passed as args",
+			args{
+				k: &client.K8sClient{
+					Ns:        "fake-ns",
+					K8sCS:     k8sCS,
+					OpenebsCS: openebsFakeClientset.NewSimpleClientset(&bd1, &bd2, &bd3),
+				},
+				bds: []string{"some-fake-bd-365"},
+			},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := createTreeByNode(tt.args.k, tt.args.bds); (err != nil) != tt.wantErr {
+				t.Errorf("createTreeByNode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -160,4 +160,15 @@ var (
 		{Name: "Storage Class", Type: "string"},
 		{Name: "Status", Type: "string"},
 	}
+
+	// BDTreeListColumnDefinations stores the Table headers for Block Device Details, when displayed as tree
+	BDTreeListColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "Path", Type: "string"},
+		{Name: "Size", Type: "string"},
+		{Name: "ClaimState", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "FsType", Type: "string"},
+		{Name: "MountPoint", Type: "string"},
+	}
 )


### PR DESCRIPTION
### What does this PR do?
- This PR adds the `blockdevice` listing command in a `tree` format by the `node-names`.
- This adds the unit testing for the `blockdevice` package.

### Command usage and output
```
$ kubectl openebs get bd
NAME                                             PATH            SIZE      CLAIMSTATE   STATUS     FSTYPE       MOUNTPOINT
minikube-1                                                                                                      
├─blockdevice-94312c16fb24476c3a155c34f0c6153a   /dev/sdb1       50 GiB    Claimed      Inactive   zfs_member   /var/openebs/zfsvol
├─blockdevice-8a5b69d8a2b23276f8daeac3c8179f9d   /dev/nvme2n1    100 GiB   Claimed      Active                  
└─blockdevice-e5a1c3c1b66c864588a66d0a7ff8ca58   /dev/nvme10n1   100 GiB   Claimed      Active                  

minikube-3                                                                                                      
└─blockdevice-94312c16fb24476c3a155c34f0c6199k   /dev/sdb1       50 GiB    Claimed      Active                  

minikube-2                                                                                                      
├─blockdevice-94312c16fb24476c3a155c34f0c211c3   /dev/sdb1       50 GiB    Unclaimed    Inactive   ext4         /var/lib/something
└─blockdevice-94312c16fb24476c3a155c34f0c2143c   /dev/sdb1       50 GiB    Claimed      Active    
```
 
```             
$ kubectl openebs get bd blockdevice-94312c16fb24476c3a155c34f0c6153a
NAME                                             PATH        SIZE     CLAIMSTATE   STATUS     FSTYPE       MOUNTPOINT
minikube-1                                                                                                 
└─blockdevice-94312c16fb24476c3a155c34f0c6153a   /dev/sdb1   50 GiB   Claimed      Inactive   zfs_member   /var/openebs/zfsvol
```

```
$ kubectl openebs get bd blockdevice-94312c16fb24476c3a155c34f0c6153a blockdevice-94312c16fb24476c3a155c34f0c2143c
NAME                                             PATH        SIZE     CLAIMSTATE   STATUS     FSTYPE       MOUNTPOINT
minikube-1                                                                                                 
└─blockdevice-94312c16fb24476c3a155c34f0c6153a   /dev/sdb1   50 GiB   Claimed      Inactive   zfs_member   /var/openebs/zfsvol

minikube-2                                                                                                 
└─blockdevice-94312c16fb24476c3a155c34f0c2143c   /dev/sdb1   50 GiB   Claimed      Active         
```

### Closes
- https://github.com/openebs/openebsctl/projects/1#card-61347232