### PR TITLE
Add lvmlocalpv vg listing & zfspool listing

### DIFF
--- a/cmd/describe/storage.go
+++ b/cmd/describe/storage.go
@@ -17,6 +17,8 @@ limitations under the License.
 package describe
 
 import (
+	"strings"
+
 	"github.com/openebs/openebsctl/pkg/storage"
 	"github.com/openebs/openebsctl/pkg/util"
 	"github.com/spf13/cobra"
@@ -50,7 +52,9 @@ func NewCmdDescribeStorage() *cobra.Command {
 		Example: `kubectl openebs describe storage storage-1`,
 		Run: func(cmd *cobra.Command, args []string) {
 			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
-			util.CheckErr(storage.Describe(args, openebsNs), util.Fatal)
+			casType, _ := cmd.Flags().GetString("cas-type")
+			casType = strings.ToLower(casType)
+			util.CheckErr(storage.Describe(args, openebsNs, casType), util.Fatal)
 		},
 	}
 	return cmd

--- a/go.sum
+++ b/go.sum
@@ -343,7 +343,6 @@ github.com/openebs/api/v2 v2.3.0/go.mod h1:nLCaNvVjgjkjeD2a+n1fMbv5HjoEYP4XB8OAb
 github.com/openebs/jiva-operator v1.12.2-0.20210607114402-811a3af7c34a h1:HuCp3D9TOhJogGTcH5JePJuebceQhPRgB5SizB0bmTg=
 github.com/openebs/jiva-operator v1.12.2-0.20210607114402-811a3af7c34a/go.mod h1:5oMQaMQKa0swN1hJnAP7CEMI/MOLVz0S2Mcu0H/l0oc=
 github.com/openebs/lib-csi v0.3.0/go.mod h1:uruyzJiTwRoytQPQXOf4spaezn1cjkiAXjvFGw6aY/8=
-github.com/openebs/lib-csi v0.6.0 h1:nucurCo91lKNhtjbYNPJIrbJU0F4oinphZtkGWI/DEY=
 github.com/openebs/lib-csi v0.6.0/go.mod h1:KWANWF2zNB8RYyELegid8PxHFrP/cdttR320NA9gVUQ=
 github.com/openebs/lvm-localpv v0.6.0 h1:2LWSF/qy6jGKNAALtIN1O5y6tEKhwTGcVUcxy0Qgnpk=
 github.com/openebs/lvm-localpv v0.6.0/go.mod h1:DVDU+pjCFdb3rZd4MwVVEZ2eXqq+LT16CpQTm1j0MYo=

--- a/pkg/client/lvmlocalpv.go
+++ b/pkg/client/lvmlocalpv.go
@@ -92,6 +92,7 @@ func (k K8sClient) GetLVMvol(lVols []string, rType util.ReturnType, labelSelecto
 	return nil, nil, errors.New("invalid return type")
 }
 
+// GetLVMNodes return a list of LVMNodes
 func (k K8sClient) GetLVMNodes() (*lvm.LVMNodeList, error) {
 	return k.LVMCS.LocalV1alpha1().LVMNodes("").List(context.TODO(), v1.ListOptions{})
 }

--- a/pkg/client/lvmlocalpv.go
+++ b/pkg/client/lvmlocalpv.go
@@ -91,3 +91,7 @@ func (k K8sClient) GetLVMvol(lVols []string, rType util.ReturnType, labelSelecto
 	}
 	return nil, nil, errors.New("invalid return type")
 }
+
+func (k K8sClient) GetLVMNodes() (*lvm.LVMNodeList, error) {
+	return k.LVMCS.LocalV1alpha1().LVMNodes("").List(context.TODO(), v1.ListOptions{})
+}

--- a/pkg/client/zfslocalpv.go
+++ b/pkg/client/zfslocalpv.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package client
 
 import (

--- a/pkg/client/zfslocalpv.go
+++ b/pkg/client/zfslocalpv.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openebs/openebsctl/pkg/util"
+	zfs "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+	zvolclient "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// getLVMClient returns OpenEBS clientset by taking kubeconfig as an
+// argument
+func getZFSclient(kubeconfig string) (*zvolclient.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not build config from flags: %v", err)
+	}
+	client, err := zvolclient.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("could not get new config: %v", err)
+	}
+	return client, nil
+}
+
+// GetZFSVols returns a list or a map of ZFSVolume depending upon rType & options
+func (k K8sClient) GetZFSVols(volNames []string, rType util.ReturnType, labelSelector string, options util.MapOptions) (*zfs.ZFSVolumeList, map[string]zfs.ZFSVolume, error) {
+	zvols, err := k.ZFCS.ZfsV1().ZFSVolumes("").List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, nil, err
+	}
+	var list []zfs.ZFSVolume
+	if len(volNames) == 0 {
+		list = zvols.Items
+	} else {
+		zvsMap := make(map[string]zfs.ZFSVolume)
+		for _, zv := range zvols.Items {
+			zvsMap[zv.Name] = zv
+		}
+		for _, name := range volNames {
+			if zv, ok := zvsMap[name]; ok {
+				list = append(list, zv)
+			} else {
+				fmt.Printf("Error from server (NotFound): zfsVolume %s not found\n", name)
+			}
+		}
+	}
+	if rType == util.List {
+		return &zfs.ZFSVolumeList{
+			Items: list,
+		}, nil, nil
+	}
+	if rType == util.Map {
+		zvMap := make(map[string]zfs.ZFSVolume)
+		switch options.Key {
+		case util.Label:
+			for _, zv := range list {
+				if vol, ok := zv.Labels[options.LabelKey]; ok {
+					zvMap[vol] = zv
+				}
+			}
+			return nil, zvMap, nil
+		case util.Name:
+			for _, zv := range list {
+				zvMap[zv.Name] = zv
+			}
+			return nil, zvMap, nil
+		default:
+			return nil, nil, fmt.Errorf("invalid map options")
+		}
+	}
+	return nil, nil, fmt.Errorf("invalid return type")
+}
+
+// GetZFSNodes return a list of ZFSNodes
+func (k K8sClient) GetZFSNodes() (*zfs.ZFSNodeList, error) {
+	return k.ZFCS.ZfsV1().ZFSNodes("").List(context.TODO(), metav1.ListOptions{})
+}

--- a/pkg/storage/cstor.go
+++ b/pkg/storage/cstor.go
@@ -76,7 +76,7 @@ func GetCstorPools(c *client.K8sClient, pools []string) error {
 			util.Duration(time.Since(item.ObjectMeta.CreationTimestamp.Time))}})
 	}
 	if len(cpools.Items) == 0 {
-		fmt.Println("No Pools are found")
+		return fmt.Errorf("no cstor pools are found")
 	} else {
 		util.TablePrinter(util.CstorPoolListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	}

--- a/pkg/storage/cstor.go
+++ b/pkg/storage/cstor.go
@@ -77,9 +77,8 @@ func GetCstorPools(c *client.K8sClient, pools []string) error {
 	}
 	if len(cpools.Items) == 0 {
 		return fmt.Errorf("no cstor pools are found")
-	} else {
-		util.TablePrinter(util.CstorPoolListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	}
+	util.TablePrinter(util.CstorPoolListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }
 

--- a/pkg/storage/lvmlocalpv.go
+++ b/pkg/storage/lvmlocalpv.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
+)
+
+const (
+	firstElemPrefix = `├─`
+	lastElemPrefix  = `└─`
+)
+
+// GetVolumeGroups lists all volume groups by node
+func GetVolumeGroups(c *client.K8sClient, vgs []string) error {
+	lvmNodes, err := c.GetLVMNodes()
+	if err != nil {
+		return err
+	}
+	var rows []metav1.TableRow
+	for _, lv := range lvmNodes.Items {
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{lv.Name, "", "", ""}})
+		for i, vg := range lv.VolumeGroups {
+			var prefix string
+			if i < len(lv.VolumeGroups)-1 {
+				prefix = firstElemPrefix
+			} else {
+				prefix = lastElemPrefix
+			}
+			rows = append(rows, metav1.TableRow{Cells: []interface{}{prefix + vg.Name,
+				util.ConvertToIBytes(vg.Free.String()), util.ConvertToIBytes(vg.Size.String())}})
+		}
+		rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", ""}})
+	}
+	// 3. Actually print the table or return an error
+	if len(rows) == 0 {
+		return fmt.Errorf("no lvm volumegroups found")
+	}
+	util.TablePrinter(util.LVMvolgroupListColumnDefinitions, rows, printers.PrintOptions{Wide: true})
+	return nil
+}
+
+func DescribeVolumeGroup(c *client.K8sClient, vg string) error {
+	return nil
+}

--- a/pkg/storage/lvmlocalpv_test.go
+++ b/pkg/storage/lvmlocalpv_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (
@@ -28,7 +44,7 @@ func TestGetVolumeGroup(t *testing.T) {
 				},
 				vg: nil,
 			},
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/lvmlocalpv_test.go
+++ b/pkg/storage/lvmlocalpv_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"testing"
+
+	fakelvmclient "github.com/openebs/lvm-localpv/pkg/generated/clientset/internalclientset/fake"
+	"github.com/openebs/openebsctl/pkg/client"
+)
+
+func TestGetVolumeGroup(t *testing.T) {
+	type args struct {
+		c  *client.K8sClient
+		vg []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"no LVM volumegroups present",
+			args{
+				c: &client.K8sClient{
+					Ns:        "lvmlocalpv",
+					K8sCS:     nil,
+					OpenebsCS: nil,
+					LVMCS:     fakelvmclient.NewSimpleClientset(),
+				},
+				vg: nil,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := GetVolumeGroups(tt.args.c, tt.args.vg); (err != nil) != tt.wantErr {
+				t.Errorf("GetVolumeGroups() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -52,7 +52,7 @@ func Get(pools []string, openebsNS string, casType string) error {
 // CasList has a list of method implementations for different cas-types
 func CasList() []func(*client.K8sClient, []string) error {
 	return []func(*client.K8sClient, []string) error{
-		GetCstorPools, GetVolumeGroups, GetZFSNodes}
+		GetCstorPools, GetVolumeGroups, GetZFSPools}
 }
 
 // Describe manages various implementations of Storage Describing
@@ -85,7 +85,7 @@ func CasListMap() map[string]func(*client.K8sClient, []string) error {
 	return map[string]func(*client.K8sClient, []string) error{
 		util.CstorCasType: GetCstorPools,
 		util.LVMLocalPV:   GetVolumeGroups,
-		util.ZFSCasType:   GetZFSNodes,
+		util.ZFSCasType:   GetZFSPools,
 	}
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -52,7 +52,7 @@ func Get(pools []string, openebsNS string, casType string) error {
 // CasList has a list of method implementations for different cas-types
 func CasList() []func(*client.K8sClient, []string) error {
 	return []func(*client.K8sClient, []string) error{
-		GetCstorPools, GetVolumeGroups}
+		GetCstorPools, GetVolumeGroups, GetZFSNodes}
 }
 
 // Describe manages various implementations of Storage Describing
@@ -85,6 +85,7 @@ func CasListMap() map[string]func(*client.K8sClient, []string) error {
 	return map[string]func(*client.K8sClient, []string) error{
 		util.CstorCasType: GetCstorPools,
 		util.LVMLocalPV:   GetVolumeGroups,
+		util.ZFSCasType:   GetZFSNodes,
 	}
 }
 
@@ -93,6 +94,5 @@ func CasDescribeMap() map[string]func(*client.K8sClient, string) error {
 	// a good hack to implement immutable maps in Golang & also write tests for it
 	return map[string]func(*client.K8sClient, string) error{
 		util.CstorCasType: DescribeCstorPool,
-		util.LVMLocalPV:   DescribeVolumeGroup,
 	}
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -69,7 +69,7 @@ func Describe(storages []string, openebsNs, casType string) error {
 	}
 	for _, storageName := range storages {
 		// 3. Describe the storage
-		if list, ok := CasDescribeMap()[casType]; ok {
+		if list, ok := CasDescribeMap()[util.CstorCasType]; ok {
 			err := list(k, storageName)
 			if err != nil {
 				return err

--- a/pkg/storage/zfslocalpv.go
+++ b/pkg/storage/zfslocalpv.go
@@ -25,8 +25,8 @@ import (
 	"k8s.io/cli-runtime/pkg/printers"
 )
 
-// GetZFSNodes lists all zfspools by zfsnodes
-func GetZFSNodes(c *client.K8sClient, zfsnodes []string) error {
+// GetZFSPools lists all zfspools by zfsnodes
+func GetZFSPools(c *client.K8sClient, zfsnodes []string) error {
 	zfsNodes, err := c.GetZFSNodes()
 	if err != nil {
 		return err

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -57,6 +57,7 @@ const (
 	// ZFSCSIDriver is the name of the ZFS localpv CSI driver
 	ZFSCSIDriver = "zfs.csi.openebs.io"
 	// LocalPVLVMCSIDriver is the name of the LVM LocalPV CSI driver
+	// NOTE: This might also mean local-hostpath, local-device or zfs-localpv later.
 	LocalPVLVMCSIDriver = "local.csi.openebs.io"
 )
 
@@ -65,11 +66,13 @@ var (
 	CasTypeAndComponentNameMap = map[string]string{
 		CstorCasType: "openebs-cstor-csi-controller",
 		JivaCasType:  "openebs-jiva-csi-controller",
+		LVMLocalPV:   "openebs-lvm-controller",
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap
 	ComponentNameToCasTypeMap = map[string]string{
 		"openebs-cstor-csi-controller": CstorCasType,
 		"openebs-jiva-csi-controller":  JivaCasType,
+		"openebs-lvm-controller":       LVMLocalPV,
 	}
 	// ProvsionerAndCasTypeMap stores the cas type name of the corresponding provisioner
 	ProvsionerAndCasTypeMap = map[string]string{
@@ -169,6 +172,12 @@ var (
 		{Name: "Status", Type: "string"},
 		{Name: "FsType", Type: "string"},
 		{Name: "MountPoint", Type: "string"},
+	}
+
+	LVMvolgroupListColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "FreeSize", Type: "string"},
+		{Name: "TotalSize", Type: "string"},
 	}
 	// JivaReplicaPVCColumnDefinations stores the Table headers for Jiva Replica PVC details
 	JivaReplicaPVCColumnDefinations = []metav1.TableColumnDefinition{

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -179,6 +179,11 @@ var (
 		{Name: "FreeSize", Type: "string"},
 		{Name: "TotalSize", Type: "string"},
 	}
+	ZFSPoolListColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Name", Type: "string"},
+		{Name: "FreeSize", Type: "string"},
+	}
+
 	// JivaReplicaPVCColumnDefinations stores the Table headers for Jiva Replica PVC details
 	JivaReplicaPVCColumnDefinations = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -173,12 +173,13 @@ var (
 		{Name: "FsType", Type: "string"},
 		{Name: "MountPoint", Type: "string"},
 	}
-
+	// LVMvolgroupListColumnDefinitions stores the table headers for listing lvm vg-group when displayed as tree
 	LVMvolgroupListColumnDefinitions = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "FreeSize", Type: "string"},
 		{Name: "TotalSize", Type: "string"},
 	}
+	// ZFSPoolListColumnDefinitions stores the table headers for listing zfs pools when displayed as tree
 	ZFSPoolListColumnDefinitions = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
 		{Name: "FreeSize", Type: "string"},

--- a/pkg/volume/jiva.go
+++ b/pkg/volume/jiva.go
@@ -73,7 +73,6 @@ func GetJiva(c *client.K8sClient, pvList *corev1.PersistentVolumeList, openebsNS
 		sc := pv.Spec.StorageClassName
 		attached := pv.Status.Phase
 		var attachedNode, storageVersion, customStatus, ns string
-		// TODO: Estimate the cas-type and decide to print it out
 		// Should all AccessModes be shown in a csv format, or the highest be displayed ROO < RWO < RWX?
 		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == util.JivaCSIDriver {
 			jv, ok := jvMap[pv.Name]


### PR DESCRIPTION
# Summary of changes

- Make ZFSlocalPV client testable & part of `pkg/client.K8sClient`, which is injected into functions which do interesting things
- Move ZFS* wrapper clients into it's own functions in `pkg/client/zfslocalpv.go`
- Call each Pool lister implementation one-by-one if no cas-type is specified in a specific deterministic order & append a system independent newline if the previous implementer function didn't return an error
- Add LVM & ZFS pool/storage listers, called lvm volume groups & zfs nodes respectively
- 


CStor, LVM & ZFS pools/storages listed together
```bash
└─ $ ▶ kubectl openebs get storage
NAME                      HOSTNAME                     FREE     CAPACITY   READ ONLY   PROVISIONED REPLICAS   HEALTHY REPLICAS   STATUS    AGE
default-cstor-disk-dcrm   ip-10-0-8-190.ec2.internal   73 GiB   90 GiB     false       7                      7                  ONLINE    58d7h
default-cstor-disk-fp6v   ip-10-0-6-143.ec2.internal   73 GiB   90 GiB     false       7                      7                  ONLINE    58d7h
default-cstor-disk-rhwj   ip-10-0-6-94.ec2.internal    73 GiB   90 GiB     false       7                      4                  OFFLINE   58d7h

NAME                    FREESIZE   TOTALSIZE
node1-virtual-machine              
└─lvmvg                 1020 GiB   1024 GiB
                                   
node2-virtual-machine              
└─lvmvg-node2           1020 GiB   1024 GiB
                                   

NAME              FREESIZE
node1         
└─zfs-test-pool   32 GiB
                  
node2         
└─zfs-test-pool   36 GiB

```


Only LVM LocalPV present

```bash
master@master-virtual-machine:~$ ./kubectl-openebs get storage
NAME                    FREESIZE   TOTALSIZE
node1-virtual-machine              
└─lvmvg                 1020 GiB   1024 GiB
                                   
node2-virtual-machine              
└─lvmvg-node2           1020 GiB   1024 GiB
```

Only ZFS LocalPV present
```bash
└─ $ ▶ kubectl openebs get storage --cas-type=zfslocalpv
NAME              FREESIZE
node1         
└─zfs-test-pool   32 GiB
                  
node2         
└─zfs-test-pool   36 GiB
                  
```

LVM & CStor pool present
```bash
➜  openebsctl git:(vggroup) ✗ ./kubectl-openebs get s
NAME                      HOSTNAME                     FREE     CAPACITY   READ ONLY   PROVISIONED REPLICAS   HEALTHY REPLICAS   STATUS    AGE
default-cstor-disk-dcrm   ip-10-0-8-190.ec2.internal   73 GiB   90 GiB     false       7                      7                  ONLINE    58d3h
default-cstor-disk-fp6v   ip-10-0-6-143.ec2.internal   73 GiB   90 GiB     false       7                      7                  ONLINE    58d3h
default-cstor-disk-rhwj   ip-10-0-6-94.ec2.internal    73 GiB   90 GiB     false       7                      4                  OFFLINE   58d3h

NAME                    FREESIZE   TOTALSIZE
node1-virtual-machine              
└─lvmvg                 1020 GiB   1024 GiB
                                   
node2-virtual-machine              
└─lvmvg-node2           1020 GiB   1024 GiB
```



Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>