### PR TITLE
feat: add golangci-lint to actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,27 +1,6 @@
 name: Go
 on: [push, pull_request]
 jobs:
-
-  lint:
-    name: Golint
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-      id: go_1
-
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Run Golint
-      run: make golint
-
-    - name: Verify License
-      run: make license-check
-
   verify-dependencies:
     name: Verify Dependencies
     runs-on: ubuntu-latest
@@ -38,7 +17,7 @@ jobs:
 
     - name: Run Deps Check
       run:  make verify-deps
-  
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - develop
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.29

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  timeout: 2m
+
+linters-settings:
+  goheader:
+    values:
+      const:
+        YEAR: 2020-2021
+        AUTHOR: The OpenEBS Authors
+    template: |-
+      Copyright {{YEAR}} {{AUTHOR}}
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,13 @@ openebsctl:
 	@sudo cp -a "$(PWD)/bin/OPENEBSCTL/${OPENEBSCTL}"  /usr/local/bin/${OPENEBSCTL}
 	@echo "=> copied to /usr/local/bin"
 
-.PHONY: golint
-golint:
-	@echo "+ Installing golint"
-	@GO111MODULE=on go get -u golang.org/x/lint/golint;
-	@echo "--> Running golint"
-	@golint -set_exit_status $(PACKAGES)
-	@echo "Golint successful !"
+.PHONY: golangci
+golangci:
+	@echo "+ Installing golangci-lint"
+	@GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1;
+	@echo "--> Running golangci-lint"
+	@golangci-lint run -set_exit_status $(PACKAGES)
+	@echo "Golangci-lint successful !"
 	@echo "--------------------------------"
 
 .PHONY: license-check


### PR DESCRIPTION
Fixes #51.

Changes:

- add golangci-lint as an action
- modify golint target in Makefile
- move license check to goheader

Signed-off-by: Aadhav Vignesh <aadhav.n1@gmail.com>