### PR TITLE
Add zfs pool & volume describe

### DIFF
--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -52,7 +52,6 @@ func NewCmdDescribe(rootCmd *cobra.Command) *cobra.Command {
 			fmt.Println(volumeCommandHelpText)
 		},
 	}
-
 	cmd.AddCommand(
 		NewCmdDescribeVolume(),
 		NewCmdDescribePVC(),

--- a/cmd/describe/storage.go
+++ b/cmd/describe/storage.go
@@ -17,8 +17,6 @@ limitations under the License.
 package describe
 
 import (
-	"strings"
-
 	"github.com/openebs/openebsctl/pkg/storage"
 	"github.com/openebs/openebsctl/pkg/util"
 	"github.com/spf13/cobra"
@@ -44,7 +42,6 @@ Filter by a fixed OpenEBS namespace
 
 // NewCmdDescribeStorage displays OpenEBS storage related information.
 func NewCmdDescribeStorage() *cobra.Command {
-	var casType string
 	cmd := &cobra.Command{
 		Use:     "storage",
 		Aliases: []string{"storages", "s"},
@@ -53,11 +50,8 @@ func NewCmdDescribeStorage() *cobra.Command {
 		Example: `kubectl openebs describe storage storage-1`,
 		Run: func(cmd *cobra.Command, args []string) {
 			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
-			casType, _ := cmd.Flags().GetString("cas-type")
-			casType = strings.ToLower(casType)
-			util.CheckErr(storage.Describe(args, openebsNs, casType), util.Fatal)
+			util.CheckErr(storage.Describe(args, openebsNs), util.Fatal)
 		},
 	}
-	cmd.PersistentFlags().StringVarP(&casType, "cas-type", "", "", "the cas-type filter option for fetching resources")
 	return cmd
 }

--- a/cmd/describe/storage.go
+++ b/cmd/describe/storage.go
@@ -44,6 +44,7 @@ Filter by a fixed OpenEBS namespace
 
 // NewCmdDescribeStorage displays OpenEBS storage related information.
 func NewCmdDescribeStorage() *cobra.Command {
+	var casType string
 	cmd := &cobra.Command{
 		Use:     "storage",
 		Aliases: []string{"storages", "s"},
@@ -57,5 +58,6 @@ func NewCmdDescribeStorage() *cobra.Command {
 			util.CheckErr(storage.Describe(args, openebsNs, casType), util.Fatal)
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&casType, "cas-type", "", "", "the cas-type filter option for fetching resources")
 	return cmd
 }

--- a/cmd/describe/storage.go
+++ b/cmd/describe/storage.go
@@ -17,6 +17,8 @@ limitations under the License.
 package describe
 
 import (
+	"strings"
+
 	"github.com/openebs/openebsctl/pkg/storage"
 	"github.com/openebs/openebsctl/pkg/util"
 	"github.com/spf13/cobra"
@@ -42,6 +44,7 @@ Filter by a fixed OpenEBS namespace
 
 // NewCmdDescribeStorage displays OpenEBS storage related information.
 func NewCmdDescribeStorage() *cobra.Command {
+	var casType string
 	cmd := &cobra.Command{
 		Use:     "storage",
 		Aliases: []string{"storages", "s"},
@@ -50,8 +53,11 @@ func NewCmdDescribeStorage() *cobra.Command {
 		Example: `kubectl openebs describe storage storage-1`,
 		Run: func(cmd *cobra.Command, args []string) {
 			openebsNs, _ := cmd.Flags().GetString("openebs-namespace")
-			util.CheckErr(storage.Describe(args, openebsNs), util.Fatal)
+			casType, _ := cmd.Flags().GetString("cas-type")
+			casType = strings.ToLower(casType)
+			util.CheckErr(storage.Describe(args, openebsNs, casType), util.Fatal)
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&casType, "cas-type", "", "", "the cas-type filter option for fetching resources")
 	return cmd
 }

--- a/cmd/describe/volume.go
+++ b/cmd/describe/volume.go
@@ -36,7 +36,6 @@ Advanced: Override the auto-detected OPENEBS_NAMESPACE
 
 // NewCmdDescribeVolume displays OpenEBS Volume information.
 func NewCmdDescribeVolume() *cobra.Command {
-	var casType string
 	cmd := &cobra.Command{
 		Use:     "volume",
 		Aliases: []string{"volumes", "vol", "v"},
@@ -49,6 +48,5 @@ func NewCmdDescribeVolume() *cobra.Command {
 			util.CheckErr(volume.Describe(args, openebsNS), util.Fatal)
 		},
 	}
-	cmd.PersistentFlags().StringVarP(&casType, "cas-type", "", "", "the cas-type filter option for fetching resources")
 	return cmd
 }

--- a/cmd/describe/volume.go
+++ b/cmd/describe/volume.go
@@ -36,6 +36,7 @@ Advanced: Override the auto-detected OPENEBS_NAMESPACE
 
 // NewCmdDescribeVolume displays OpenEBS Volume information.
 func NewCmdDescribeVolume() *cobra.Command {
+	var casType string
 	cmd := &cobra.Command{
 		Use:     "volume",
 		Aliases: []string{"volumes", "vol", "v"},
@@ -48,5 +49,6 @@ func NewCmdDescribeVolume() *cobra.Command {
 			util.CheckErr(volume.Describe(args, openebsNS), util.Fatal)
 		},
 	}
+	cmd.PersistentFlags().StringVarP(&casType, "cas-type", "", "", "the cas-type filter option for fetching resources")
 	return cmd
 }

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -554,7 +554,8 @@ func (k K8sClient) GetCSPIs(cspiNames []string, labelselector string) (*cstorv1.
 		if pool, ok := poolMap[name]; ok {
 			list = append(list, pool)
 		} else {
-			fmt.Printf("Error from server (NotFound): pool %s not found\n", name)
+			// This logging might be omitted
+			// fmt.Fprintf(os.Stderr, "Error from server (NotFound): pool %s not found\n", name)
 		}
 	}
 	return &cstorv1.CStorPoolInstanceList{

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -553,10 +553,11 @@ func (k K8sClient) GetCSPIs(cspiNames []string, labelselector string) (*cstorv1.
 	for _, name := range cspiNames {
 		if pool, ok := poolMap[name]; ok {
 			list = append(list, pool)
-		} else {
-			// This logging might be omitted
-			// fmt.Fprintf(os.Stderr, "Error from server (NotFound): pool %s not found\n", name)
 		}
+		// else {
+		// This logging might be omitted
+		// fmt.Fprintf(os.Stderr, "Error from server (NotFound): pool %s not found\n", name)
+		//}
 	}
 	return &cstorv1.CStorPoolInstanceList{
 		Items: list,

--- a/pkg/client/zfslocalpv.go
+++ b/pkg/client/zfslocalpv.go
@@ -108,6 +108,7 @@ func (k K8sClient) GetZFSNodes(volNames []string, rType util.ReturnType, labelSe
 			if zv, ok := zvsMap[name]; ok {
 				list = append(list, zv)
 			} else {
+				// This might be omitted
 				fmt.Printf("Error from server (NotFound): zfsVolume %s not found\n", name)
 			}
 		}

--- a/pkg/storage/cstor.go
+++ b/pkg/storage/cstor.go
@@ -70,11 +70,14 @@ func GetCstorPools(c *client.K8sClient, pools []string) ([]metav1.TableColumnDef
 
 // DescribeCstorPool method runs info command and make call to DisplayPoolInfo to display the results
 func DescribeCstorPool(c *client.K8sClient, poolName string) error {
-	poolInfo, err := c.GetCSPI(poolName)
+	pools, err := c.GetCSPIs([]string{poolName}, "")
 	if err != nil {
-		return errors.Wrap(err, "Error getting pool info")
+		return errors.Wrap(err, "error getting pool info")
 	}
-
+	if len(pools.Items) == 0 {
+		return fmt.Errorf("cstor-pool %s not found", poolName)
+	}
+	poolInfo := pools.Items[0]
 	poolDetails := util.PoolInfo{
 		Name:           poolInfo.Name,
 		HostName:       poolInfo.Spec.HostName,

--- a/pkg/storage/cstor.go
+++ b/pkg/storage/cstor.go
@@ -31,8 +31,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	cStorPoolInstanceInfoTemplate = `
+const cStorPoolInstanceInfoTemplate = `
 {{.Name}} Details :
 ----------------
 NAME             : {{.Name}}
@@ -43,7 +42,6 @@ READ ONLY STATUS : {{.ReadOnlyStatus}}
 STATUS	         : {{.Status}}
 RAID TYPE        : {{.RaidType}}
 `
-)
 
 // GetCstorPools lists the pools
 func GetCstorPools(c *client.K8sClient, pools []string) ([]metav1.TableColumnDefinition, []metav1.TableRow, error) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -77,8 +77,6 @@ func Describe(storages []string, openebsNs, casType string) error {
 			}
 		} else if val, ok := nsMap[casType]; ok {
 			k.Ns = val
-		} else {
-			return fmt.Errorf("please specify a valid --cas-type and --openebs-namespace")
 		}
 	}
 	// 3. Run a specific cas-type function

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -85,12 +85,11 @@ func Describe(storages []string, openebsNs, casType string) error {
 	if casType != "" {
 		if work, ok := CasDescribeMap()[casType]; ok {
 			for _, storage := range storages {
-				work(k, storage)
+				_ = work(k, storage)
 			}
 			return nil
-		} else {
-			return fmt.Errorf("")
 		}
+		return fmt.Errorf("cas-type %s unknown", casType)
 	}
 
 	// 4. Brute-force run describe the storage by all cas-type functions

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -60,44 +60,16 @@ func CasList() []func(*client.K8sClient, []string) ([]metav1.TableColumnDefiniti
 }
 
 // Describe manages various implementations of Storage Describing
-func Describe(storages []string, openebsNs, casType string) error {
+func Describe(storages []string, openebsNs string) error {
 	// 1. Create the clientset
 	k, _ := client.NewK8sClient(openebsNs)
-	// 2. Get the namespace
-	nsMap, _ := k.GetOpenEBSNamespaceMap()
-	if openebsNs == "" {
-		if casType == util.ZFSCasType {
-			// a temporary way to get the zfs-namespace
-			zfs, _, err := k.GetZFSNodes(nil, util.List, "", util.MapOptions{})
-			if err != nil {
-				return fmt.Errorf("please specify --openebs-namespace for ZFS LocalPV")
-			}
-			if zfs != nil && zfs.Items != nil && len(zfs.Items) > 0 {
-				k.Ns = zfs.Items[0].Namespace
-			}
-		} else if val, ok := nsMap[casType]; ok {
-			k.Ns = val
-		}
-	}
-	// 3. Run a specific cas-type function
-	if casType != "" {
-		if work, ok := CasDescribeMap()[casType]; ok {
-			for _, storage := range storages {
-				_ = work(k, storage)
-			}
-			return nil
-		}
-		return fmt.Errorf("cas-type %s unknown", casType)
-	}
-
-	// 4. Brute-force run describe the storage by all cas-type functions
+	// 2. Brute-force run describe the storage by all cas-type functions
 	for _, storageName := range storages {
 		for _, work := range CasDescribeList() {
 			if err := work(k, storageName); err == nil {
 				continue
 			}
 			// TODO: Should the errors be logged
-			// Should we ask the user to specify a cas-type for a useful error
 		}
 	}
 	return nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -93,9 +93,7 @@ func Describe(storages []string, openebsNs, casType string) error {
 	// 4. Brute-force run describe the storage by all cas-type functions
 	for _, storageName := range storages {
 		for _, work := range CasDescribeList() {
-			if err := work(k, storageName); err == nil {
-				continue
-			}
+			_ = work(k, storageName)
 			// TODO: Should the errors be logged
 			// Should we ask the user to specify a cas-type for a useful error
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -35,9 +35,8 @@ func Get(pools []string, openebsNS string, casType string) error {
 		header, rows, err := f(k, pools)
 		if err != nil {
 			return err
-		} else {
-			util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
 		}
+		util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
 	} else if casType != "" {
 		return fmt.Errorf("cas-type %s is not supported", casType)
 	}
@@ -64,21 +63,44 @@ func CasList() []func(*client.K8sClient, []string) ([]metav1.TableColumnDefiniti
 func Describe(storages []string, openebsNs, casType string) error {
 	// 1. Create the clientset
 	k, _ := client.NewK8sClient(openebsNs)
-	// 2. Get the namespaces
+	// 2. Get the namespace
 	nsMap, _ := k.GetOpenEBSNamespaceMap()
 	if openebsNs == "" {
-		// TODO: Change this line, currently this overwriting empty flag values as cstor
-		if val, ok := nsMap[util.CstorCasType]; ok {
+		if casType == util.ZFSCasType {
+			// a temporary way to get the zfs-namespace
+			zfs, _, err := k.GetZFSNodes(nil, util.List, "", util.MapOptions{})
+			if err != nil {
+				return fmt.Errorf("please specify --openebs-namespace for ZFS LocalPV")
+			}
+			if zfs != nil && zfs.Items != nil && len(zfs.Items) > 0 {
+				k.Ns = zfs.Items[0].Namespace
+			}
+		} else if val, ok := nsMap[casType]; ok {
 			k.Ns = val
+		} else {
+			return fmt.Errorf("please specify a valid --cas-type and --openebs-namespace")
 		}
 	}
-	for _, storageName := range storages {
-		// 3. Describe the storage
-		if list, ok := CasDescribeMap()[util.CstorCasType]; ok {
-			err := list(k, storageName)
-			if err != nil {
-				return err
+	// 3. Run a specific cas-type function
+	if casType != "" {
+		if work, ok := CasDescribeMap()[casType]; ok {
+			for _, storage := range storages {
+				work(k, storage)
 			}
+			return nil
+		} else {
+			return fmt.Errorf("")
+		}
+	}
+
+	// 4. Brute-force run describe the storage by all cas-type functions
+	for _, storageName := range storages {
+		for _, work := range CasDescribeList() {
+			if err := work(k, storageName); err == nil {
+				continue
+			}
+			// TODO: Should the errors be logged
+			// Should we ask the user to specify a cas-type for a useful error
 		}
 	}
 	return nil
@@ -99,5 +121,11 @@ func CasDescribeMap() map[string]func(*client.K8sClient, string) error {
 	// a good hack to implement immutable maps in Golang & also write tests for it
 	return map[string]func(*client.K8sClient, string) error{
 		util.CstorCasType: DescribeCstorPool,
+		util.ZFSCasType:   DescribeZFSNode,
 	}
+}
+
+// CasDescribeList returns a list of functions which describe a Storage i.e. a pool/volume-group
+func CasDescribeList() []func(*client.K8sClient, string) error {
+	return []func(*client.K8sClient, string) error{DescribeCstorPool, DescribeZFSNode}
 }

--- a/pkg/storage/testdata_test.go
+++ b/pkg/storage/testdata_test.go
@@ -247,3 +247,17 @@ var zfsNode2 = zfs.ZFSNode{
 	Pools: []zfs.Pool{{Name: "zfs-pool2", UUID: "15423895941648453428", Free: resource.MustParse("33285828Ki")},
 		{Name: "zfs-pool3", UUID: "15423895941648453426", Free: resource.MustParse("33285828Ki")}},
 }
+
+var zfsNode3 = zfs.ZFSNode{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ZFSNode",
+		APIVersion: "zfs.openebs.io/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "node3",
+		Namespace: "zfs",
+		// OwnerReference: refers to the K8s-node where the zfs volume is created
+	},
+	Pools: []zfs.Pool{{Name: "zfs-pool1", UUID: "15423895941648453428", Free: resource.MustParse("33285828")},
+		{Name: "zfs-poolX", UUID: "15423895941648453426", Free: resource.MustParse("33285828Ki")}},
+}

--- a/pkg/storage/zfslocalpv.go
+++ b/pkg/storage/zfslocalpv.go
@@ -21,12 +21,22 @@ import (
 
 	"github.com/openebs/openebsctl/pkg/client"
 	"github.com/openebs/openebsctl/pkg/util"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const zfsdesc = `
+{{.HostName}} Details :
+
+HOSTNAME      : {{.HostName}}
+Namespace     : {{.Namespace}}
+NumberOfPools : {{.NumberOfPools}}
+TotalFree     : {{.TotalFree}}
+`
+
 // GetZFSPools lists all zfspools by zfsnodes
 func GetZFSPools(c *client.K8sClient, zfsnodes []string) ([]metav1.TableColumnDefinition, []metav1.TableRow, error) {
-	zfsNodes, err := c.GetZFSNodes()
+	zfsNodes, _, err := c.GetZFSNodes(zfsnodes, util.List, "", util.MapOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -50,4 +60,33 @@ func GetZFSPools(c *client.K8sClient, zfsnodes []string) ([]metav1.TableColumnDe
 		return nil, nil, fmt.Errorf("no zfspools found")
 	}
 	return util.ZFSPoolListColumnDefinitions, rows, nil
+}
+
+// ZfsNodeDesc describes a zfsnode
+type ZfsNodeDesc struct {
+	HostName      string
+	Namespace     string
+	NumberOfPools int
+	TotalFree     string
+}
+
+// DescribeZFSNode describes a ZFS node & the zfspools present in it
+func DescribeZFSNode(c *client.K8sClient, sName string) error {
+	zfsInfo, _, err := c.GetZFSNodes([]string{sName}, util.List, "", util.MapOptions{})
+	if err != nil {
+		return err
+	}
+	zfsN := zfsInfo.Items[0]
+	var totalFree resource.Quantity
+	for _, pools := range zfsN.Pools {
+		// TODO: handle case when size is just represented in numbers of bytes
+		totalFree.Add(pools.Free)
+	}
+	desc := ZfsNodeDesc{
+		HostName:      zfsN.Name,
+		Namespace:     zfsN.Namespace,
+		NumberOfPools: len(zfsN.Pools),
+		TotalFree:     util.ConvertToIBytes(totalFree.String()),
+	}
+	return util.PrintByTemplate("zfsnodes", zfsdesc, desc)
 }

--- a/pkg/storage/zfslocalpv.go
+++ b/pkg/storage/zfslocalpv.go
@@ -28,10 +28,10 @@ import (
 const zfsdesc = `
 {{.HostName}} Details :
 
-HOSTNAME      : {{.HostName}}
-Namespace     : {{.Namespace}}
-NumberOfPools : {{.NumberOfPools}}
-TotalFree     : {{.TotalFree}}
+HOSTNAME        : {{.HostName}}
+NAMESPACE       : {{.Namespace}}
+NUMBER OF POOLS : {{.NumberOfPools}}
+TOTAL FREE      : {{.TotalFree}}
 `
 
 // GetZFSPools lists all zfspools by zfsnodes

--- a/pkg/storage/zfslocalpv.go
+++ b/pkg/storage/zfslocalpv.go
@@ -76,6 +76,9 @@ func DescribeZFSNode(c *client.K8sClient, sName string) error {
 	if err != nil {
 		return err
 	}
+	if len(zfsInfo.Items) == 0 {
+		return fmt.Errorf("zfsnode %s not found", sName)
+	}
 	zfsN := zfsInfo.Items[0]
 	var totalFree resource.Quantity
 	for _, pools := range zfsN.Pools {

--- a/pkg/storage/zfslocalpv_test.go
+++ b/pkg/storage/zfslocalpv_test.go
@@ -106,9 +106,14 @@ func TestDescribeZFSNode(t *testing.T) {
 			false,
 		},
 		{
-			"one ZFS node exist",
+			"one ZFS node exist with differing size units",
 			args{c: &client.K8sClient{Ns: "zfs", ZFCS: fakezfsclient.NewSimpleClientset(&zfsNode3)}, sName: "node3"},
 			false,
+		},
+		{
+			"two ZFS node exist, none asked for",
+			args{c: &client.K8sClient{Ns: "zfs", ZFCS: fakezfsclient.NewSimpleClientset(&zfsNode1, &zfsNode3)}, sName: "cstor-pool-name"},
+			true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/zfslocalpv_test.go
+++ b/pkg/storage/zfslocalpv_test.go
@@ -84,6 +84,45 @@ func TestGetZFSPools(t *testing.T) {
 	}
 }
 
+func TestDescribeZFSNode(t *testing.T) {
+	type args struct {
+		c       *client.K8sClient
+		zfsfunc func(*client.K8sClient)
+		sName   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"no ZFS nodes exist",
+			args{c: &client.K8sClient{Ns: "", ZFCS: fakezfsclient.NewSimpleClientset()}, zfsfunc: zfsNodeNotFound, sName: "zfs-pv1"},
+			true,
+		},
+		{
+			"one ZFS node exist",
+			args{c: &client.K8sClient{Ns: "zfs", ZFCS: fakezfsclient.NewSimpleClientset(&zfsNode1)}, sName: "node1"},
+			false,
+		},
+		{
+			"one ZFS node exist",
+			args{c: &client.K8sClient{Ns: "zfs", ZFCS: fakezfsclient.NewSimpleClientset(&zfsNode3)}, sName: "node3"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.zfsfunc != nil {
+				tt.args.zfsfunc(tt.args.c)
+			}
+			if err := DescribeZFSNode(tt.args.c, tt.args.sName); (err != nil) != tt.wantErr {
+				t.Errorf("DescribeZFSNode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // lvnNodeNotFound makes fakelvmClientSet return error
 func zfsNodeNotFound(c *client.K8sClient) {
 	// NOTE: Set the VERB & Resource correctly & make it work for single resources

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -19,12 +19,6 @@ package util
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
-	// MinWidth used in tabwriter
-	MinWidth = 0
-	// MaxWidth used in tabwriter
-	MaxWidth = 0
-	// Padding used in tabwriter
-	Padding = 4
 	// OpenEBSCasTypeKey present in label of PV
 	OpenEBSCasTypeKey = "openebs.io/cas-type"
 	// Unknown to be retuned when cas type is not known
@@ -61,14 +55,28 @@ const (
 	LocalPVLVMCSIDriver = "local.csi.openebs.io"
 )
 
+// Constant CSI component-name label values
+const (
+	// CStorCSIControllerLabelValue is the label value of CSI controller STS & pod
+	CStorCSIControllerLabelValue = "openebs-cstor-csi-controller"
+	// JivaCSIControllerLabelValue is the label value of CSI controller STS & pod
+	JivaCSIControllerLabelValue = "openebs-jiva-csi-controller"
+	// LVMLocalPVcsiControllerLabelValue is the label value of CSI controller STS & pod
+	LVMLocalPVcsiControllerLabelValue = "openebs-lvm-controller"
+	// ZFSLocalPVcsiControllerLabelValue is the label value of CSI controller STS & pod
+	ZFSLocalPVcsiControllerLabelValue = "openebs-zfs-controller"
+)
+
 var (
 	// CasTypeAndComponentNameMap stores the component name of the corresponding cas type
+	// NOTE: Not including ZFSLocalPV as it'd break existing code
 	CasTypeAndComponentNameMap = map[string]string{
-		CstorCasType: "openebs-cstor-csi-controller",
-		JivaCasType:  "openebs-jiva-csi-controller",
-		LVMLocalPV:   "openebs-lvm-controller",
+		CstorCasType: CStorCSIControllerLabelValue,
+		JivaCasType:  JivaCSIControllerLabelValue,
+		LVMLocalPV:   LVMLocalPVcsiControllerLabelValue,
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap
+	// NOTE: Not including ZFSLocalPV as it'd break existing code
 	ComponentNameToCasTypeMap = map[string]string{
 		"openebs-cstor-csi-controller": CstorCasType,
 		"openebs-jiva-csi-controller":  JivaCasType,
@@ -80,8 +88,9 @@ var (
 		// This isn't supported by CLI
 		"openebs.io/provisioner-iscsi": JivaCasType,
 		"openebs.io/local":             "local",
-		"local.csi.openebs.io":         "localpv-lvm",
-		"zfs.csi.openebs.io":           "localpv-zfs",
+		// NOTE: In near future this might mean all local-pv volumes
+		"local.csi.openebs.io": LVMLocalPV,
+		"zfs.csi.openebs.io":   ZFSCasType,
 	}
 	// CstorReplicaColumnDefinations stores the Table headers for CVR Details
 	CstorReplicaColumnDefinations = []metav1.TableColumnDefinition{

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -85,12 +85,10 @@ var (
 	// ProvsionerAndCasTypeMap stores the cas type name of the corresponding provisioner
 	ProvsionerAndCasTypeMap = map[string]string{
 		CStorCSIDriver: CstorCasType,
-		// This isn't supported by CLI
-		"openebs.io/provisioner-iscsi": JivaCasType,
-		"openebs.io/local":             "local",
+		JivaCSIDriver:  JivaCasType,
 		// NOTE: In near future this might mean all local-pv volumes
-		"local.csi.openebs.io": LVMLocalPV,
-		"zfs.csi.openebs.io":   ZFSCasType,
+		LocalPVLVMCSIDriver: LVMLocalPV,
+		ZFSCSIDriver:        ZFSCasType,
 	}
 	// CstorReplicaColumnDefinations stores the Table headers for CVR Details
 	CstorReplicaColumnDefinations = []metav1.TableColumnDefinition{

--- a/pkg/util/k8s_utils.go
+++ b/pkg/util/k8s_utils.go
@@ -68,6 +68,11 @@ func GetCasTypeFromPV(v1PV *corev1.PersistentVolume) string {
 				return val
 			}
 		}
+		if v1PV.Spec.CSI != nil {
+			if val, ok := ProvsionerAndCasTypeMap[v1PV.Spec.CSI.Driver]; ok {
+				return val
+			}
+		}
 	}
 	return Unknown
 }

--- a/pkg/util/k8s_utils_test.go
+++ b/pkg/util/k8s_utils_test.go
@@ -145,6 +145,11 @@ func TestGetCasTypeFromPV(t *testing.T) {
 			},
 			"unknown",
 		},
+		{
+			"zfs pv, from CSI driver",
+			args{v1PV: &zfspv},
+			"zfslocalpv",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/testdata_test.go
+++ b/pkg/util/testdata_test.go
@@ -54,6 +54,9 @@ var (
 		},
 		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
 	}
+	zfspv = corev1.PersistentVolume{
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: ZFSCSIDriver}}}}
 
 	cstorSC = v1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/volume/testdata_test.go
+++ b/pkg/volume/testdata_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package volume
 
 import (
+	"time"
+
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 	lvm "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
@@ -26,13 +28,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // Some storage sizes for PVs
 var (
 	fourGigiByte = resource.MustParse("4Gi")
-	blockFS = corev1.PersistentVolumeBlock
+	blockFS      = corev1.PersistentVolumeBlock
 )
 
 /****************
@@ -509,12 +510,15 @@ var zfsVol1 = zfs.ZFSVolume{
 		OwnerNodeID:   "node1",
 		PoolName:      "zfspv",
 		Capacity:      "4Gi",
-		Shared:        "NotShared",
+		RecordSize:    "4k",
+		Compression:   "off",
+		Dedup:         "off",
 		ThinProvision: "No",
+		VolumeType:    "DATASET",
+		FsType:        "zfs",
+		Shared:        "NotShared",
 	},
-	Status: zfs.VolStatus{
-		State: "Ready",
-	},
+	Status: zfs.VolStatus{State: "Ready"},
 }
 
 var zfsPV1 = corev1.PersistentVolume{
@@ -529,10 +533,11 @@ var zfsPV1 = corev1.PersistentVolume{
 	},
 	Spec: corev1.PersistentVolumeSpec{
 		// 4GiB
-		Capacity:                      corev1.ResourceList{corev1.ResourceStorage: fourGigiByte},
-		PersistentVolumeSource:        corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: util.ZFSCSIDriver}},
-		AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-		ClaimRef:                      nil,
+		Capacity:               corev1.ResourceList{corev1.ResourceStorage: fourGigiByte},
+		PersistentVolumeSource: corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: util.ZFSCSIDriver}},
+		AccessModes:            []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		ClaimRef: &corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "pvc-namespace",
+			Name: "zfs-pvc-1", APIVersion: "v1"},
 		PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
 		StorageClassName:              "zfs-sc-1",
 		VolumeMode:                    &blockFS,

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -94,6 +94,20 @@ func Describe(vols []string, openebsNs string) error {
 		if openebsNs == "" {
 			if val, ok := nsMap[casType]; ok {
 				k.Ns = val
+			} else if casType == util.ZFSCasType {
+				// edge case: ZFS LocalPV resources are not created in kube-system
+				// namespace where the ZFS CSI STS is scheduled
+				zfs, _, err := k.GetZFSVols(nil, util.List, "", util.MapOptions{})
+				if err != nil {
+					return errors.New("please specify --openebs-namespace for ZFS LocalPV")
+				}
+				if zfs != nil && zfs.Items != nil && len(zfs.Items) > 0 {
+					k.Ns = zfs.Items[0].Namespace
+				}
+				err = DescribeZFSLocalPVs(k, &pv)
+				if err != nil {
+					return err
+				}
 			} else {
 				return errors.New("could not determine the underlying storage engine ns, please provide using '--openebs-namespace' flag")
 			}
@@ -132,5 +146,6 @@ func CasDescribeMap() map[string]func(*client.K8sClient, *corev1.PersistentVolum
 	return map[string]func(*client.K8sClient, *corev1.PersistentVolume) error{
 		util.JivaCasType:  DescribeJivaVolume,
 		util.CstorCasType: DescribeCstorVolume,
+		util.ZFSCasType:   DescribeZFSLocalPVs,
 	}
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -104,7 +104,6 @@ func Describe(vols []string, openebsNs string) error {
 				if zfs != nil && zfs.Items != nil && len(zfs.Items) > 0 {
 					k.Ns = zfs.Items[0].Namespace
 				}
-				err = DescribeZFSLocalPVs(k, &pv)
 				if err != nil {
 					return err
 				}

--- a/pkg/volume/zfs_locapv.go
+++ b/pkg/volume/zfs_locapv.go
@@ -38,7 +38,7 @@ PVC           : {{.PVC}}
 VolumePhase   : {{.VolumePhase}}
 StorageClass  : {{.StorageClass}}
 Version       : {{.Version}}
-Status        : {{.Status}
+Status        : {{.Status}}
 VolumeType    : {{.VolumeType}}
 PoolName      : {{.PoolName}}
 FileSystem    : {{.FileSystem}}

--- a/pkg/volume/zfs_locapv.go
+++ b/pkg/volume/zfs_locapv.go
@@ -143,7 +143,7 @@ func DescribeZFSLocalPVs(c *client.K8sClient, vol *corev1.PersistentVolume) erro
 		Capacity:   vol.Spec.Capacity.Storage().String(),
 		CSIDriver:  vol.Spec.CSI.Driver,
 		Name:       vol.Name,
-		Namespace:  zvol.Name,
+		Namespace:  zvol.Namespace,
 		// assuming that zfsPVs aren't static-ally provisioned
 		PVC:          vol.Spec.ClaimRef.Name,
 		VolumePhase:  vol.Status.Phase,


### PR DESCRIPTION
## Describe ZFS & CStor storage with & without flags

```bash
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe s zfs-node1

zfs-node1 Details :

HOSTNAME        : zfs-node1
NAMESPACE       : openebs
NUMBER OF POOLS : 1
TOTAL FREE      : 32 GiB

# also works with the `openebs-namespace` flag
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe s zfs-node1 --cas-type=zfslocalpv

zfs-node1 Details :

HOSTNAME        : zfs-node1
NAMESPACE       : openebs
NUMBER OF POOLS : 1
TOTAL FREE      : 32 GiB

# CSTOR still works, even without the flags, because it'd brute-force each implementation till one of them don't return a non-nil error which would stop the execution
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe s default-cstor-disk-rhwj

default-cstor-disk-rhwj Details :
----------------
NAME             : default-cstor-disk-rhwj
HOSTNAME         : ip-10-0-6-143.ec2.internal
SIZE             : 90 GiB
FREE CAPACITY    : 73 GiB
READ ONLY STATUS : false
STATUS	         : OFFLINE
RAID TYPE        : stripe
....

# CSTOR with explicit flags also works
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe s default-cstor-disk-rhwj --cas-type=cstor

default-cstor-disk-rhwj Details :
----------------
NAME             : default-cstor-disk-rhwj
HOSTNAME         : ip-10-0-6-143.ec2.internal
SIZE             : 90 GiB
FREE CAPACITY    : 73 GiB
READ ONLY STATUS : false
STATUS	         : OFFLINE
RAID TYPE        : stripe
....

# wrongly given cas-types won't work and throw an apt error
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs get s --cas-type=dummy
cas-type dummy is not supported

```

## Describe volumes 

```bash
➜  openebsctl git:(zfs_desc) ✗ ./openebsctl describe v pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452

pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452 Details :
-----------------
Name          : pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452
Namespace     : openebs
AccessMode    : ReadWriteOnce 
CSIDriver     : zfs.csi.openebs.io
Capacity      : 4Gi
PVC           : csi-zfspv
VolumePhase   : Released
StorageClass  : openebs-zfspv
Version       : N/A
Status        : Ready
VolumeType    : DATASET
PoolName      : zfspv-pool
FileSystem    : zfs
Compression   : off
Deduplication : off
NodeID        : worker-sh1
Recordsize    : 4k

# no cas-type flags required for describing volumes as that info is estimated from the CSI.Driver string & StorageClass(if one CSI driver can provision n different types of cas-type
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe v pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452

pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452 Details :
-----------------
Name          : pvc-43fcbc72-a45a-49d5-9ec3-e383fcb91452
Namespace     : openebs
AccessMode    : ReadWriteOnce 
CSIDriver     : zfs.csi.openebs.io
Capacity      : 4Gi
PVC           : csi-zfspv
VolumePhase   : Released
StorageClass  : openebs-zfspv
Version       : N/A
Status        : Ready
VolumeType    : DATASET
PoolName      : zfspv-pool
FileSystem    : zfs
Compression   : off
Deduplication : off
NodeID        : worker-sh1
Recordsize    : 4k

# jiva volume describe without explicit flags works
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe vol pvc-478a8329-f02d-47e5-8288-0c28b582be25

pvc-478a8329-f02d-47e5-8288-0c28b582be25 Details :
-----------------
NAME            : pvc-478a8329-f02d-47e5-8288-0c28b582be25
ACCESS MODE     : ReadWriteOnce 
CSI DRIVER      : jiva.csi.openebs.io
STORAGE CLASS   : openebs-jiva-csi-sc
VOLUME PHASE    : Released
VERSION         : 2.9.0
JVP             : jivavolumepolicy
SIZE            : 4.0 GiB
STATUS          : RW
REPLICA COUNT	: 1


Portal Details :
------------------
IQN              :  iqn.2016-09.com.openebs.jiva:pvc-478a8329-f02d-47e5-8288-0c28b582be25
VOLUME NAME      :  pvc-478a8329-f02d-47e5-8288-0c28b582be25
TARGET NODE NAME :  minikube
PORTAL           :  10.101.211.252:3260


No replicas found for the JivaVolumepvc-478a8329-f02d-47e5-8288-0c28b582be25

# jiva volume describe also works when only OPENEBS_NAMESPACE is specified(i.e. estimating OPENEBS_NAMESPACE when cas-type isn't provided almost always works)
➜  openebsctl git:(zfs_desc) ✗ kubectl openebs describe v pvc-478a8329-f02d-47e5-8288-0c28b582be25 --openebs-namespace=jiva

pvc-478a8329-f02d-47e5-8288-0c28b582be25 Details :
-----------------
NAME            : pvc-478a8329-f02d-47e5-8288-0c28b582be25
ACCESS MODE     : ReadWriteOnce 
CSI DRIVER      : jiva.csi.openebs.io
STORAGE CLASS   : openebs-jiva-csi-sc
VOLUME PHASE    : Released
VERSION         : 2.9.0
JVP             : jivavolumepolicy
SIZE            : 4.0 GiB
STATUS          : RW
REPLICA COUNT	: 1


Portal Details :
------------------
IQN              :  iqn.2016-09.com.openebs.jiva:pvc-478a8329-f02d-47e5-8288-0c28b582be25
VOLUME NAME      :  pvc-478a8329-f02d-47e5-8288-0c28b582be25
TARGET NODE NAME :  minikube
PORTAL           :  10.101.211.252:3260

No replicas found for the JivaVolumepvc-478a8329-f02d-47e5-8288-0c28b582be25

```

fixes: #37