### PR TITLE
feat(volume debugger): Add module for PVC events display

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/docker/go-units v0.4.0
-	github.com/fatih/color v1.7.0
 	github.com/openebs/api/v2 v2.3.0
 	github.com/openebs/jiva-operator v1.12.2-0.20210607114402-811a3af7c34a
 	github.com/openebs/lvm-localpv v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -114,7 +114,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -295,10 +294,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pkg/persistentvolumeclaim/debug_cstor.go
+++ b/pkg/persistentvolumeclaim/debug_cstor.go
@@ -18,7 +18,6 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"os"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
@@ -100,9 +99,9 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 		availableCapacity = util.GetAvailableCapacity(totalCapacity, usedCapacity)
 		percentage := util.GetUsedPercentage(totalCapacity, usedCapacity)
 		if percentage >= 80.00 {
-			availableCapacity = color.HiRedString(availableCapacity)
+			availableCapacity = util.ColorText(availableCapacity, util.Red)
 		} else {
-			availableCapacity = color.HiGreenString(availableCapacity)
+			availableCapacity = util.ColorText(availableCapacity, util.Green)
 		}
 	}
 	// 3. Display the usage status
@@ -190,7 +189,7 @@ func displayPVCEvents(k client.K8sClient, crs util.CstorVolumeResources) error {
 	events, err := k.GetEvents(fmt.Sprintf("regarding.name=%s,regarding.kind=PersistentVolumeClaim", crs.PVC.Name))
 	// 3. Display the events
 	if len(events.Items) != 0 && err == nil {
-		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", color.HiRedString(fmt.Sprintf(" %s %d! ", util.UnicodeCross, len(events.Items))), "-------->\n")
+		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCross, len(events.Items)), util.Red), "-------->\n")
 		var crStatusRows []metav1.TableRow
 		for _, event := range events.Items {
 			crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{event.Action, event.Reason, event.Note, util.ColorStringOnStatus(event.Type)}})
@@ -198,10 +197,9 @@ func displayPVCEvents(k client.K8sClient, crs util.CstorVolumeResources) error {
 		defer util.TablePrinter(util.EventsColumnDefinitions, crStatusRows, printers.PrintOptions{})
 		return nil
 	} else if len(events.Items) == 0 && err == nil {
-		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", color.HiGreenString(fmt.Sprintf(" %s %d! ", util.UnicodeCheck, len(events.Items))), "-------->\n")
+		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCheck, len(events.Items)), util.Green), "-------->\n")
 		return nil
 	} else {
 		return err
 	}
-
 }

--- a/pkg/persistentvolumeclaim/debug_cstor.go
+++ b/pkg/persistentvolumeclaim/debug_cstor.go
@@ -18,7 +18,6 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
-	"os"
 
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
 	"github.com/openebs/openebsctl/pkg/client"
@@ -105,11 +104,14 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 		}
 	}
 	// 3. Display the usage status
-	_, _ = fmt.Fprint(os.Stdout, "Volume Usage Stats:\n-------------------\n")
+	fmt.Println("Volume Usage Stats:")
+	fmt.Println("-------------------")
 
 	util.TablePrinter(util.VolumeTotalAndUsageDetailColumnDefinitions, []metav1.TableRow{{Cells: []interface{}{totalCapacity, usedCapacity, availableCapacity}}}, printers.PrintOptions{})
 
-	_, _ = fmt.Fprint(os.Stdout, "\nRelated CR Statuses:\n--------------------\n")
+	fmt.Println()
+	fmt.Println("Related CR Statuses:")
+	fmt.Println("--------------------")
 
 	var crStatusRows []metav1.TableRow
 	if crs.PV != nil {
@@ -117,28 +119,30 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 	} else {
 		crStatusRows = append(
 			crStatusRows,
-			metav1.TableRow{Cells: []interface{}{"PersistentVolume", "", util.ColorStringOnStatus("Not Found")}},
+			metav1.TableRow{Cells: []interface{}{"PersistentVolume", "", util.ColorStringOnStatus(util.NotFound)}},
 		)
 	}
 	if crs.CV != nil {
 		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolume", crs.CV.Name, util.ColorStringOnStatus(string(crs.CV.Status.Phase))}})
 	} else {
-		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolume", "", util.ColorStringOnStatus("Not Found")}})
+		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolume", "", util.ColorStringOnStatus(util.NotFound)}})
 	}
 	if crs.CVC != nil {
 		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeConfig", crs.CVC.Name, util.ColorStringOnStatus(string(crs.CVC.Status.Phase))}})
 	} else {
-		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeConfig", "", util.ColorStringOnStatus("Not Found")}})
+		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeConfig", "", util.ColorStringOnStatus(util.NotFound)}})
 	}
 	if crs.CVA != nil {
-		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeAttachment", crs.CVA.Name, util.ColorStringOnStatus("Attached")}})
+		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeAttachment", crs.CVA.Name, util.ColorStringOnStatus(util.Attached)}})
 	} else {
-		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeAttachment", "", util.ColorStringOnStatus("Volume Not Attached to Application")}})
+		crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"CstorVolumeAttachment", "", util.ColorStringOnStatus(util.CVANotAttached)}})
 	}
 	// 4. Display the CRs statuses
 	util.TablePrinter(util.CstorVolumeCRStatusColumnDefinitions, crStatusRows, printers.PrintOptions{})
 
-	_, _ = fmt.Fprint(os.Stdout, "\nReplica Statuses:\n-----------------\n")
+	fmt.Println()
+	fmt.Println("Replica Statuses:")
+	fmt.Println("-----------------")
 	crStatusRows = []metav1.TableRow{}
 	if crs.CVRs != nil {
 		for _, item := range crs.CVRs.Items {
@@ -148,7 +152,9 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 	// 5. Display the CRs statuses
 	util.TablePrinter(util.CstorVolumeCRStatusColumnDefinitions, crStatusRows, printers.PrintOptions{})
 
-	_, _ = fmt.Fprint(os.Stdout, "\nBlockDevice and BlockDeviceClaim Statuses:\n------------------------------------------\n")
+	fmt.Println()
+	fmt.Println("BlockDevice and BlockDeviceClaim Statuses:")
+	fmt.Println("------------------------------------------")
 	crStatusRows = []metav1.TableRow{}
 	if crs.PresentBDs != nil {
 		for _, item := range crs.PresentBDs.Items {
@@ -156,7 +162,7 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 		}
 		for key, val := range crs.ExpectedBDs {
 			if !val {
-				crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"BlockDevice", key, util.ColorStringOnStatus("Not Found")}})
+				crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{"BlockDevice", key, util.ColorStringOnStatus(util.NotFound)}})
 			}
 		}
 	}
@@ -169,7 +175,9 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 	// 6. Display the BDs and BDCs statuses
 	util.TablePrinter(util.CstorVolumeCRStatusColumnDefinitions, crStatusRows, printers.PrintOptions{})
 
-	_, _ = fmt.Fprint(os.Stdout, "\nPool Instance Statuses:\n-----------------------\n")
+	fmt.Println()
+	fmt.Println("Pool Instance Statuses:")
+	fmt.Println("-----------------------")
 	crStatusRows = []metav1.TableRow{}
 	if crs.CSPIs != nil {
 		for _, item := range crs.CSPIs.Items {
@@ -185,19 +193,21 @@ func resourceStatus(crs util.CstorVolumeResources) error {
 func displayPVCEvents(k client.K8sClient, crs util.CstorVolumeResources) error {
 	// 1. Set the namespace of the resource to the client
 	k.Ns = crs.PVC.Namespace
-	// 2. Fetch the events of the concerned PVC
+	// 2. Fetch the events of the concerned PVC.
+	// The PVCs donot have the Kind filled, thus we have hardcoded here.
 	events, err := k.GetEvents(fmt.Sprintf("regarding.name=%s,regarding.kind=PersistentVolumeClaim", crs.PVC.Name))
 	// 3. Display the events
-	if len(events.Items) != 0 && err == nil {
-		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCross, len(events.Items)), util.Red), "-------->\n")
+	fmt.Println()
+	if err == nil && len(events.Items) == 0 {
+		fmt.Println("Checking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCross, len(events.Items)), util.Red), "-------->")
 		var crStatusRows []metav1.TableRow
 		for _, event := range events.Items {
 			crStatusRows = append(crStatusRows, metav1.TableRow{Cells: []interface{}{event.Action, event.Reason, event.Note, util.ColorStringOnStatus(event.Type)}})
 		}
-		defer util.TablePrinter(util.EventsColumnDefinitions, crStatusRows, printers.PrintOptions{})
+		util.TablePrinter(util.EventsColumnDefinitions, crStatusRows, printers.PrintOptions{})
 		return nil
 	} else if len(events.Items) == 0 && err == nil {
-		_, _ = fmt.Fprint(os.Stdout, "\nChecking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCheck, len(events.Items)), util.Green), "-------->\n")
+		fmt.Println("Checking PVC Events:", util.ColorText(fmt.Sprintf(" %s %d! ", util.UnicodeCheck, len(events.Items)), util.Green), "-------->")
 		return nil
 	} else {
 		return err

--- a/pkg/persistentvolumeclaim/debug_cstor_test.go
+++ b/pkg/persistentvolumeclaim/debug_cstor_test.go
@@ -19,6 +19,8 @@ package persistentvolumeclaim
 import (
 	"testing"
 
+	"github.com/openebs/openebsctl/pkg/util"
+
 	"github.com/openebs/openebsctl/pkg/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,6 +64,56 @@ func TestDebugCstorVolumeClaim(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := DebugCstorVolumeClaim(tt.args.k, tt.args.pvc, tt.args.pv); (err != nil) != tt.wantErr {
 				t.Errorf("DebugCstorVolumeClaim() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_displayPVCEvents(t *testing.T) {
+	k, _ := client.NewK8sClient("openebs")
+	type args struct {
+		k   *client.K8sClient
+		crs util.CstorVolumeResources
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"test 1",
+			args{k: k, crs: util.CstorVolumeResources{}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := displayPVCEvents(*tt.args.k, tt.args.crs); (err != nil) != tt.wantErr {
+				t.Errorf("displayPVCEvents() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_resourceStatus(t *testing.T) {
+	type args struct {
+		crs util.CstorVolumeResources
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"test 1",
+			args{crs: util.CstorVolumeResources{}},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := resourceStatus(tt.args.crs); (err != nil) != tt.wantErr {
+				t.Errorf("resourceStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -41,6 +41,10 @@ const (
 	NotAttached = "N/A"
 	// CVAVolnameKey present in label of CVA
 	CVAVolnameKey = "Volname"
+	// UnicodeCross stores the character representation of U+274C
+	UnicodeCross = "❌"
+	// UnicodeCheck stores the character representation of U+2714
+	UnicodeCheck = "✔"
 )
 
 const (
@@ -214,5 +218,12 @@ var (
 		{Name: "Total Capacity", Type: "string"},
 		{Name: "Used Capacity", Type: "string"},
 		{Name: "Available Capacity", Type: "string"},
+	}
+	// EventsColumnDefinitions stores the Table headers for events details
+	EventsColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Action", Type: "string"},
+		{Name: "Reason", Type: "string"},
+		{Name: "Message", Type: "string"},
+		{Name: "Type", Type: "string"},
 	}
 )

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -45,6 +45,12 @@ const (
 	UnicodeCross = "❌"
 	// UnicodeCheck stores the character representation of U+2714
 	UnicodeCheck = "✔"
+	// NotFound stores the Not Found Status
+	NotFound = "Not Found"
+	// CVANotAttached stores CVA Not Attached status
+	CVANotAttached = "Not Attached to Application"
+	// Attached stores CVA Attached Status
+	Attached = "Attached"
 )
 
 const (

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -25,8 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
-
 	"github.com/docker/go-units"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +37,25 @@ import (
 const (
 	maxTerms                = 2
 	stringsToBeColoredGreen = "healthy bound online active claimed running attached normal"
+	colorFmt                = "\x1b[%dm%s\x1b[0m"
 )
+
+// Color describes a terminal color.
+type Color int
+
+// Defines basic ANSI colors.
+const (
+	Red   Color = iota + 31 // 31
+	Green                   // 32
+)
+
+// ColorText returns an ASCII colored string based on given color.
+func ColorText(s string, c Color) string {
+	if c == 0 {
+		return s
+	}
+	return fmt.Sprintf(colorFmt, c, s)
+}
 
 // Fatal prints the message (if provided) and then exits. If V(2) or greater,
 // klog.Fatal is invoked for extended information.
@@ -150,8 +166,8 @@ func GetUsedPercentage(total string, used string) float64 {
 // ColorStringOnStatus is used for coloring the strings based on statuses
 func ColorStringOnStatus(stringToColor string) string {
 	if strings.Contains(stringsToBeColoredGreen, strings.ToLower(stringToColor)) {
-		return color.HiGreenString(stringToColor)
+		return ColorText(stringToColor, Green)
 	} else {
-		return color.HiRedString(stringToColor)
+		return ColorText(stringToColor, Red)
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,7 +36,10 @@ import (
 	"k8s.io/klog"
 )
 
-const maxTerms = 2
+const (
+	maxTerms                = 2
+	stringsToBeColoredGreen = "healthy bound online active claimed running attached normal"
+)
 
 // Fatal prints the message (if provided) and then exits. If V(2) or greater,
 // klog.Fatal is invoked for extended information.
@@ -146,7 +149,7 @@ func GetUsedPercentage(total string, used string) float64 {
 
 // ColorStringOnStatus is used for coloring the strings based on statuses
 func ColorStringOnStatus(stringToColor string) string {
-	if stringToColor == "Healthy" || stringToColor == "Bound" || stringToColor == "Active" || stringToColor == "Running" || stringToColor == "Attached" || stringToColor == "ONLINE" {
+	if strings.Contains(stringsToBeColoredGreen, strings.ToLower(stringToColor)) {
 		return color.HiGreenString(stringToColor)
 	} else {
 		return color.HiRedString(stringToColor)


### PR DESCRIPTION
### What does this PR do?
- This PR adds the module for fetching and displaying PVC events.
- This also includes some refactors.
- Replaces the `faith/color` package with own implementation.

### Output
1. If `events` occurred.
![Screenshot from 2021-08-09 13-49-57](https://user-images.githubusercontent.com/32007083/128681447-9be93339-5449-4048-828e-3f9f1a7b1174.png)

2. If `events` did not occur.
![Screenshot from 2021-08-09 13-52-42](https://user-images.githubusercontent.com/32007083/128681492-2fb2b591-7d0b-4ce8-89f7-e6377e764785.png)
