### PR TITLE
Minor code & config fixes for inclusion to the krew index

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,9 +26,10 @@ archives:
       - goos: 'windows'
         format: 'zip'
 
-    wrap_in_directory: true
+    wrap_in_directory: false
     files:
       - README.md
+      - LICENSE
     replacements:
       darwin: Darwin
       linux: Linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,7 +26,7 @@ archives:
       - goos: 'windows'
         format: 'zip'
 
-    wrap_in_directory: false
+    wrap_in_directory: true
     files:
       - README.md
       - LICENSE

--- a/pkg/client/lvmlocalpv.go
+++ b/pkg/client/lvmlocalpv.go
@@ -26,6 +26,9 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
+
+	// required for auth, see: https://github.com/kubernetes/client-go/tree/v0.17.3/plugin/pkg/client/auth
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // getLVMClient returns OpenEBS clientset by taking kubeconfig as an

--- a/pkg/client/zfslocalpv.go
+++ b/pkg/client/zfslocalpv.go
@@ -25,6 +25,9 @@ import (
 	zvolclient "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
+
+	// required for auth, see: https://github.com/kubernetes/client-go/tree/v0.17.3/plugin/pkg/client/auth
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // getLVMClient returns OpenEBS clientset by taking kubeconfig as an


### PR DESCRIPTION
Summary of changes:

1. Add auth plugins for localpv clientsets, ref: [auth-plugins](https://github.com/kubernetes/client-go/tree/v12.0.0/plugin/pkg/client/auth)
2. Include LICENSE file per good practices,


**TODO**:
- Update the installer shell-script to skip the directory path to get to the `kubectl-openebs` binary

improvement: #72, `https://github.com/kubernetes-sigs/krew-index/pull/1460`