### PR TITLE
enhancement(jiva describe): Add missing replica related details to Jiva Volume and PVC describe

### DIFF
--- a/pkg/persistentvolumeclaim/jiva.go
+++ b/pkg/persistentvolumeclaim/jiva.go
@@ -18,6 +18,7 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openebs/openebsctl/pkg/client"
@@ -50,7 +51,7 @@ func DescribeJivaVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCl
 	// 1. Get the JivaVolume Corresponding to the pvc name
 	jv, err := c.GetJV(pvc.Spec.VolumeName)
 	if err != nil {
-		fmt.Printf("failed to get JivaVolume for %s\n", pvc.Spec.VolumeName)
+		fmt.Println(fmt.Sprintf("failed to get JivaVolume for %s", pvc.Spec.VolumeName))
 	}
 	// 2. Fill in Jiva Volume Claim related details
 	jivaPvcInfo := util.JivaPVCInfo{
@@ -68,34 +69,58 @@ func DescribeJivaVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCl
 	}
 	if vol != nil {
 		jivaPvcInfo.PVStatus = vol.Status.Phase
+		// 3. Print the Jiva Volume Claim information
+		_ = util.PrintByTemplate("jivaPvcInfo", jivaPvcInfoTemplate, jivaPvcInfo)
+	} else {
+		_ = util.PrintByTemplate("jivaPvcInfo", jivaPvcInfoTemplate, jivaPvcInfo)
+		fmt.Println(fmt.Sprintf("PersistentVolume %s, doesnot exist", pvc.Spec.VolumeName))
+		return nil
 	}
-	// 3. Print the Jiva Volume Claim information
-	_ = util.PrintByTemplate("jivaPvcInfo", jivaPvcInfoTemplate, jivaPvcInfo)
 	// 4. Print the Portal Information
+	replicaPodIPAndModeMap := make(map[string]string)
 	if jv != nil {
 		util.TemplatePrinter(volume.JivaPortalTemplate, jv)
+		// Create Replica IP to Mode Map
+		if jv.Status.ReplicaStatuses != nil && len(jv.Status.ReplicaStatuses) != 0 {
+			for _, replicaStatus := range jv.Status.ReplicaStatuses {
+				replicaPodIPAndModeMap[strings.Split(replicaStatus.Address, ":")[1][2:]] = replicaStatus.Mode
+			}
+		}
 	}
 	// 5. Fetch the Jiva controller and replica pod details
-	podList, err := c.GetJVTargetPod(jv.Name)
+	podList, err := c.GetJVTargetPod(vol.Name)
 	if err == nil {
-		fmt.Printf("Controller and Replica Pod Details :" + "\n-----------------------------------\n")
+		fmt.Println("Controller and Replica Pod Details :")
+		fmt.Println("-----------------------------------")
 		var rows []metav1.TableRow
 		for _, pod := range podList.Items {
-			rows = append(rows, metav1.TableRow{Cells: []interface{}{
-				pod.Namespace, pod.Name,
-				util.GetReadyContainers(pod.Status.ContainerStatuses),
-				pod.Status.Phase, util.Duration(time.Since(pod.ObjectMeta.CreationTimestamp.Time)),
-				pod.Status.PodIP, pod.Spec.NodeName}})
+			if strings.Contains(pod.Name, "-ctrl-") {
+				rows = append(rows, metav1.TableRow{Cells: []interface{}{
+					pod.Namespace, pod.Name, jv.Status.Status,
+					pod.Spec.NodeName, pod.Status.Phase, pod.Status.PodIP,
+					util.GetReadyContainers(pod.Status.ContainerStatuses),
+					util.Duration(time.Since(pod.ObjectMeta.CreationTimestamp.Time))}})
+			} else {
+				if val, ok := replicaPodIPAndModeMap[pod.Status.PodIP]; ok {
+					rows = append(rows, metav1.TableRow{Cells: []interface{}{
+						pod.Namespace, pod.Name, val,
+						pod.Spec.NodeName, pod.Status.Phase, pod.Status.PodIP,
+						util.GetReadyContainers(pod.Status.ContainerStatuses),
+						util.Duration(time.Since(pod.ObjectMeta.CreationTimestamp.Time))}})
+				}
+			}
 		}
-		util.TablePrinter(util.PodDetailsColumnDefinations, rows, printers.PrintOptions{Wide: true})
+		util.TablePrinter(util.JivaPodDetailsColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	} else {
-		fmt.Printf("Controller and Replica Pod Details :\n-----------------------------------\nNo Controller and Replica pod exists for the JivaVolume\n")
+		fmt.Printf("Controller and Replica Pod Details :")
+		fmt.Println("-----------------------------------")
+		fmt.Println("No Controller and Replica pod exists for the JivaVolume")
 	}
 	// 6. Fetch the replica PVCs and create rows for cli-runtime
 	var rows []metav1.TableRow
-	pvcList, err := c.GetPVCs(jv.Namespace, nil, "openebs.io/component=jiva-replica,openebs.io/persistent-volume="+jv.Name)
+	pvcList, err := c.GetPVCs(c.Ns, nil, "openebs.io/component=jiva-replica,openebs.io/persistent-volume="+jv.Name)
 	if err != nil || len(pvcList.Items) == 0 {
-		fmt.Printf("No replicas found for the JivaVolume %s", jv.Name)
+		fmt.Printf("No replicas found for the JivaVolume %s", vol.Name)
 		return nil
 	}
 	for _, pvc := range pvcList.Items {
@@ -109,7 +134,9 @@ func DescribeJivaVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCl
 			pvc.Spec.VolumeMode}})
 	}
 	// 6. Print the replica details if present
-	fmt.Printf("\n\nReplica Details :\n-----------------\n")
+	fmt.Println()
+	fmt.Println("Replica Data Volume Details :")
+	fmt.Println("-----------------------------")
 	util.TablePrinter(util.JivaReplicaPVCColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }

--- a/pkg/persistentvolumeclaim/jiva.go
+++ b/pkg/persistentvolumeclaim/jiva.go
@@ -18,6 +18,7 @@ package persistentvolumeclaim
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -51,7 +52,7 @@ func DescribeJivaVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCl
 	// 1. Get the JivaVolume Corresponding to the pvc name
 	jv, err := c.GetJV(pvc.Spec.VolumeName)
 	if err != nil {
-		fmt.Printf("failed to get JivaVolume for %s", pvc.Spec.VolumeName)
+		_, _ = fmt.Fprintf(os.Stderr, "failed to get JivaVolume for %s", pvc.Spec.VolumeName)
 		fmt.Println()
 	}
 	// 2. Fill in Jiva Volume Claim related details
@@ -74,7 +75,7 @@ func DescribeJivaVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCl
 		_ = util.PrintByTemplate("jivaPvcInfo", jivaPvcInfoTemplate, jivaPvcInfo)
 	} else {
 		_ = util.PrintByTemplate("jivaPvcInfo", jivaPvcInfoTemplate, jivaPvcInfo)
-		fmt.Printf("PersistentVolume %s, doesnot exist", pvc.Spec.VolumeName)
+		_, _ = fmt.Fprintf(os.Stderr, "PersistentVolume %s, doesnot exist", pvc.Spec.VolumeName)
 		fmt.Println()
 		return nil
 	}

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -120,6 +120,17 @@ var (
 		{Name: "IP", Type: "string"},
 		{Name: "Node", Type: "string"},
 	}
+	// JivaPodDetailsColumnDefinations stores the Table headers for Jiva Pod Details
+	JivaPodDetailsColumnDefinations = []metav1.TableColumnDefinition{
+		{Name: "Namespace", Type: "string"},
+		{Name: "Name", Type: "string"},
+		{Name: "Mode", Type: "string"},
+		{Name: "Node", Type: "string"},
+		{Name: "Status", Type: "string"},
+		{Name: "IP", Type: "string"},
+		{Name: "Ready", Type: "string"},
+		{Name: "Age", Type: "string"},
+	}
 	// VolumeListColumnDefinations stores the Table headers for Volume Details
 	VolumeListColumnDefinations = []metav1.TableColumnDefinition{
 		{Name: "Namespace", Type: "string"},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -131,7 +131,7 @@ func TemplatePrinter(template string, obj runtime.Object) {
 	p.AllowMissingKeys(true)
 	buffer := &bytes.Buffer{}
 	_ = p.PrintObj(obj, buffer)
-	fmt.Println(buffer)
+	fmt.Print(buffer)
 }
 
 // ConvertToIBytes humanizes all the passed units to IBytes format


### PR DESCRIPTION
### What does this PR do?
- Rename `Replica Details` ---> `Replica Volume Data Details`.
-  Adds one more column MODE which will denote the (RW or WO or NA ), under `Controller and Replica Pod Details` section.
- Add the `Controller and Replica Pod Details` and `Replica Volume Data Details` sections in Jiva Volume describe as well.
- Closes #82 

### Usage and Output
- Jiva PVC Describe
```
❯ kubectl openebs describe pvc jiva-csi-pvc

jiva-csi-pvc Details  :
-------------------
NAME               : jiva-csi-pvc
NAMESPACE          : default
CAS TYPE           : jiva
BOUND VOLUME       : pvc-d6349231-a863-4d01-962e-24a4b372050d
ATTACHED TO NODE   : node2-virtual-machine
JIVA VOLUME POLICY : jivavolumepolicy
STORAGE CLASS      : openebs-jiva-csi-sc
SIZE               : 4Gi
JV STATUS          : RW
PV STATUS          : Bound

Portal Details :
------------------
IQN              :  iqn.2016-09.com.openebs.jiva:pvc-d6349231-a863-4d01-962e-24a4b372050d
VOLUME NAME      :  pvc-d6349231-a863-4d01-962e-24a4b372050d
TARGET NODE NAME :  node2-virtual-machine
PORTAL           :  10.106.182.76:3260

Controller and Replica Pod Details :
-----------------------------------
NAMESPACE   NAME                                                              MODE   NODE                    STATUS    IP             READY   AGE
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-ctrl-575cc6cgj272   RW     node2-virtual-machine   Running   192.168.2.33   1/1     22h28m
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-0               RW     node2-virtual-machine   Running   192.168.2.35   1/1     22h28m
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-1               RW     node1-virtual-machine   Running   192.168.1.21   1/1     22h28m

Replica Data Volume Details :
-----------------------------
NAME                                                          STATUS   VOLUME                                     CAPACITY   STORAGECLASS       AGE
openebs-pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-0   Bound    pvc-19af6af5-34e1-4ab4-8401-07269c4084fa   4.0GiB     openebs-hostpath   22h28m
openebs-pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-1   Bound    pvc-50a75a4d-a809-45e0-8b48-167e8e5a2c17   4.0GiB     openebs-hostpath   22h28m

```
- Jiva Volume Describe

```
❯ kubectl openebs describe vol pvc-d6349231-a863-4d01-962e-24a4b372050d

pvc-d6349231-a863-4d01-962e-24a4b372050d Details :
-----------------
NAME            : pvc-d6349231-a863-4d01-962e-24a4b372050d
ACCESS MODE     : ReadWriteOnce 
CSI DRIVER      : jiva.csi.openebs.io
STORAGE CLASS   : openebs-jiva-csi-sc
VOLUME PHASE    : Bound
VERSION         : 2.11.0
JVP             : jivavolumepolicy
SIZE            : 4.0GiB
STATUS          : RW
REPLICA COUNT	: 2


Portal Details :
------------------
IQN              :  iqn.2016-09.com.openebs.jiva:pvc-d6349231-a863-4d01-962e-24a4b372050d
VOLUME NAME      :  pvc-d6349231-a863-4d01-962e-24a4b372050d
TARGET NODE NAME :  node2-virtual-machine
PORTAL           :  10.106.182.76:3260

Controller and Replica Pod Details :
-----------------------------------
NAMESPACE   NAME                                                              MODE   NODE                    STATUS    IP             READY   AGE
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-ctrl-575cc6cgj272   RW     node2-virtual-machine   Running   192.168.2.33   1/1     22h28m
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-0               RW     node2-virtual-machine   Running   192.168.2.35   1/1     22h28m
jiva        pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-1               RW     node1-virtual-machine   Running   192.168.1.21   1/1     22h28m

Replica Data Volume Details :
-----------------------------
NAME                                                          STATUS   VOLUME                                     CAPACITY   STORAGECLASS       AGE
openebs-pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-0   Bound    pvc-19af6af5-34e1-4ab4-8401-07269c4084fa   4.0GiB     openebs-hostpath   22h28m
openebs-pvc-d6349231-a863-4d01-962e-24a4b372050d-jiva-rep-1   Bound    pvc-50a75a4d-a809-45e0-8b48-167e8e5a2c17   4.0GiB     openebs-hostpath   22h28m

```
