### PR TITLE
Add CSPC patch to move pool's disks from an older to newer node after disks have moved to newer node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # vendor directory
 vendor
 dist/
+
+# IDE specific directory
+.idea/

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -19,16 +19,19 @@ package cmd
 import (
 	"flag"
 
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	cluster_info "github.com/openebs/openebsctl/cmd/cluster-info"
 	"github.com/openebs/openebsctl/cmd/completion"
 	"github.com/openebs/openebsctl/cmd/describe"
 	"github.com/openebs/openebsctl/cmd/generate"
 	"github.com/openebs/openebsctl/cmd/get"
+	"github.com/openebs/openebsctl/cmd/update"
 	"github.com/openebs/openebsctl/cmd/upgrade"
 	v "github.com/openebs/openebsctl/cmd/version"
 	"github.com/openebs/openebsctl/pkg/util"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -84,6 +87,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 		cluster_info.NewCmdClusterInfo(cmd),
 		upgrade.NewCmdVolumeUpgrade(cmd),
 		generate.NewCmdGenerate(),
+		update.NewCmdUpdate(cmd),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.PersistentFlags().StringVarP(&util.Kubeconfig, "kubeconfig", "c", "", "path to config file")

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"flag"
 
-	"github.com/openebs/openebsctl/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -87,7 +86,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 		cluster_info.NewCmdClusterInfo(cmd),
 		upgrade.NewCmdVolumeUpgrade(cmd),
 		generate.NewCmdGenerate(),
-		update.NewCmdUpdate(cmd),
+		update.NewCmdUpdate(),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.PersistentFlags().StringVarP(&util.Kubeconfig, "kubeconfig", "c", "", "path to config file")

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -29,10 +29,12 @@ const (
 
 $ kubectl openebs update [resource-type] [resource-names]  [arguments...] [options...]
 `
+	cspcPatchHelp = `Update CSPC to move pools from an old node to the newer
+node after the blockdevices have moved to the newer node.`
 )
 
 // NewCmdUpdate provides options for managing OpenEBS resources
-func NewCmdUpdate(rootCmd *cobra.Command) *cobra.Command {
+func NewCmdUpdate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:       "update",
 		Short:     "Provides update operations related to an OpenEBS resource",
@@ -48,6 +50,7 @@ func NewCmdUpdate(rootCmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
+// NewCmdCSPCNodePatch provides option to patch CStor CSPC
 func NewCmdCSPCNodePatch() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "storage",
@@ -55,15 +58,12 @@ func NewCmdCSPCNodePatch() *cobra.Command {
 		Short:   "Updates information about a storage",
 		Long:    updateCmdHelp,
 		Run: func(cmd *cobra.Command, args []string) {
-			// openebsNS, _ := cmd.Flags().GetString("openebs-namespace")
 			if len(args) == 3 {
 				util.CheckErr(storage.CSPCnodeChange(nil, args[0], args[1], args[2]), util.Fatal)
 			} else {
-				fmt.Println(updateCmdHelp)
+				fmt.Println(cspcPatchHelp)
 			}
 		},
 	}
 	return cmd
 }
-
-

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -65,7 +65,8 @@ func NewCmdCSPCNodePatch() *cobra.Command {
 				ns, _ := cmd.Flags().GetString("openebs-namespace")
 				fromNode, _ := cmd.Flags().GetString("from-node")
 				toNode, _ := cmd.Flags().GetString("to-node")
-				util.CheckErr(storage.Update(ns, args[0], fromNode, toNode), util.Fatal)
+				debug, _ := cmd.Flags().GetBool("debug")
+				util.CheckErr(storage.Update(ns, args[0], fromNode, toNode, debug), util.Fatal)
 			} else {
 				fmt.Println(cspcPatchHelp)
 			}
@@ -75,5 +76,6 @@ func NewCmdCSPCNodePatch() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&toNode, "to-node", "", "", "--to-node flag has the name of the new node")
 	cmd.PersistentFlags().StringVarP(&fromNode, "from-node", "", "",
 		"--from-node has the name of the old/unhealthy node")
+	cmd.PersistentFlags().Bool("debug", false, "--debug flag to enable debug mode and figure out node automatically")
 	return cmd
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -59,7 +59,8 @@ func NewCmdCSPCNodePatch() *cobra.Command {
 		Long:    updateCmdHelp,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 3 {
-				util.CheckErr(storage.CSPCnodeChange(nil, args[0], args[1], args[2]), util.Fatal)
+				ns, _ := cmd.Flags().GetString("openebs-namespace")
+				util.CheckErr(storage.Update(ns, args[0], args[1], args[2]), util.Fatal)
 			} else {
 				fmt.Println(cspcPatchHelp)
 			}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -30,7 +30,10 @@ const (
 $ kubectl openebs update [resource-type] [resource-names]  [arguments...] [options...]
 `
 	cspcPatchHelp = `Update CSPC to move pools from an old node to the newer
-node after the blockdevices have moved to the newer node.`
+node after the blockdevices have moved to the newer node.
+
+$ kubectl openebs update storage [pool-name] --from-node=old-node --to-node=new-node
+`
 )
 
 // NewCmdUpdate provides options for managing OpenEBS resources
@@ -58,13 +61,19 @@ func NewCmdCSPCNodePatch() *cobra.Command {
 		Short:   "Updates information about a storage",
 		Long:    updateCmdHelp,
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 3 {
+			if len(args) == 1 {
 				ns, _ := cmd.Flags().GetString("openebs-namespace")
-				util.CheckErr(storage.Update(ns, args[0], args[1], args[2]), util.Fatal)
+				fromNode, _ := cmd.Flags().GetString("from-node")
+				toNode, _ := cmd.Flags().GetString("to-node")
+				util.CheckErr(storage.Update(ns, args[0], fromNode, toNode), util.Fatal)
 			} else {
 				fmt.Println(cspcPatchHelp)
 			}
 		},
 	}
+	var toNode, fromNode string
+	cmd.PersistentFlags().StringVarP(&toNode, "to-node", "", "", "--to-node flag has the name of the new node")
+	cmd.PersistentFlags().StringVarP(&fromNode, "from-node", "", "",
+		"--from-node has the name of the old/unhealthy node")
 	return cmd
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"fmt"
+
+	"github.com/openebs/openebsctl/pkg/storage"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+const (
+	updateCmdHelp = `Modify one or many OpenEBS resources like storage
+
+$ kubectl openebs update [resource-type] [resource-names]  [arguments...] [options...]
+`
+)
+
+// NewCmdUpdate provides options for managing OpenEBS resources
+func NewCmdUpdate(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:       "update",
+		Short:     "Provides update operations related to an OpenEBS resource",
+		ValidArgs: []string{"storage"},
+		Long:      updateCmdHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(updateCmdHelp)
+		},
+	}
+	cmd.AddCommand(
+		NewCmdCSPCNodePatch(),
+	)
+	return cmd
+}
+
+func NewCmdCSPCNodePatch() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "storage",
+		Aliases: []string{"s", "storages", "pool"},
+		Short:   "Updates information about a storage",
+		Long:    updateCmdHelp,
+		Run: func(cmd *cobra.Command, args []string) {
+			// openebsNS, _ := cmd.Flags().GetString("openebs-namespace")
+			if len(args) == 3 {
+				util.CheckErr(storage.CSPCnodeChange(nil, args[0], args[1], args[2]), util.Fatal)
+			} else {
+				fmt.Println(updateCmdHelp)
+			}
+		},
+	}
+	return cmd
+}
+
+

--- a/docs/cstor/README.md
+++ b/docs/cstor/README.md
@@ -95,6 +95,11 @@
       NAME                                                               PVC NAME   SIZE      STATE
       pvc-b84f60ae-3f26-4110-a85d-bce7ec00dacc-default-cstor-disk-fp6v   mongo      992 MiB   Healthy
       ```
+    * #### Update a pool after disks have moved
+      ```bash
+      $ kubectl openebs update storage default-cstor-disk --from-node=node1-virtual-machine --to-node=node1-failover
+      # the relevant node selectors get updated
+      ```
     * #### Describe `cstor` pvcs
       Describe any PVC using this command, it will determine the cas engine and show details accordingly.
       ```bash

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -216,7 +216,7 @@ func (k K8sClient) GetOpenEBSNamespaceMap() (map[string]string, error) {
 	return NSmap, nil
 }
 
-// Get Versions of different components running in K8s
+// GetVersionMapOfComponents returns of different components running in K8s mapped to version
 func (k K8sClient) GetVersionMapOfComponents() (map[string]string, error) {
 	label := "openebs.io/component-name in ("
 	for _, v := range util.CasTypeAndComponentNameMap {
@@ -249,6 +249,7 @@ func (k K8sClient) GetVersionMapOfComponents() (map[string]string, error) {
 /**
 CORE RESOURCES
 */
+
 // GetPods returns the corev1 Pods based on the label and field selectors
 func (k K8sClient) GetPods(labelSelector string, fieldSelector string, namespace string) (*corev1.PodList, error) {
 	pods, err := k.K8sCS.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
@@ -521,4 +522,9 @@ func (k K8sClient) GetNodes(nodes []string, label, field string) (*corev1.NodeLi
 	return &corev1.NodeList{
 		Items: items,
 	}, nil
+}
+
+// GetNode returns the node with the name node
+func (k K8sClient) GetNode(node string) (*corev1.Node, error) {
+	return k.K8sCS.CoreV1().Nodes().Get(context.TODO(), node, metav1.GetOptions{})
 }

--- a/pkg/storage/cstor_update.go
+++ b/pkg/storage/cstor_update.go
@@ -84,7 +84,7 @@ func DebugCSPCNode(k *client.K8sClient, cspc string) (map[string]string, error) 
 		}
 	}
 	// 3. Fetch all the BDs
-	bds, err := k.GetBDs(devices, "")
+	bds, _ := k.GetBDs(devices, "")
 	actualBDToHost := make(map[string]string)
 	for _, bd := range bds.Items {
 		actualBDToHost[bd.Name] = bd.Labels["kubernetes.io/hostname"]

--- a/pkg/storage/cstor_update.go
+++ b/pkg/storage/cstor_update.go
@@ -14,9 +14,6 @@ import (
 
 // CSPCnodeChange helps patch the CSPC for older nodes
 func CSPCnodeChange(k *client.K8sClient, poolName, oldNode, newNode string) error {
-	if k == nil {
-		k, _ = client.NewK8sClient("openebs")
-	}
 	cspc, err := k.GetCSPC(poolName)
 	if err != nil {
 		return fmt.Errorf("CStor pool cluster %s not found", poolName)

--- a/pkg/storage/cstor_update.go
+++ b/pkg/storage/cstor_update.go
@@ -1,0 +1,45 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	"github.com/openebs/openebsctl/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// CSPCnodeChange helps patch the CSPC for older nodes
+func CSPCnodeChange(k *client.K8sClient, poolName, oldNode, newNode string) error {
+	if k == nil {
+		k, _ = client.NewK8sClient("openebs")
+	}
+	cspc, err := k.GetCSPC(poolName)
+	if err != nil {
+		return fmt.Errorf("CStor pool cluster %s not found", poolName)
+	}
+	var newPool cstorv1.CStorPoolCluster
+	_, err = k.GetNode(newNode)
+	if err != nil {
+		return fmt.Errorf("node %s not found", newNode)
+	}
+	// TODO: Find a good way to figure out if the newer node is more suitable for the disk-replacement
+	//return fmt.Errorf("node %s not in a good state", newNode)
+	cspc.DeepCopyInto(&newPool)
+	for _, pi := range cspc.Spec.Pools {
+		if pi.NodeSelector["kubernetes.io/hostname"] == oldNode {
+			pi.NodeSelector["kubernetes.io/hostname"] = newNode
+		}
+	}
+
+	// cspis, _ := k.GetCSPIs(nil, "openebs.io/cas-type=cstor,openebs.io/cstor-pool-cluster="+cspc.Name)
+	oldCSPC, _ := json.Marshal(cspc)
+	newCSPC, _ := json.Marshal(newPool)
+	data, err := strategicpatch.CreateTwoWayMergePatch(oldCSPC, newCSPC, cspc)
+	_, err = k.OpenebsCS.CstorV1().CStorPoolClusters(k.Ns).Patch(context.TODO(), poolName,
+		types.StrategicMergePatchType, data, metav1.PatchOptions{}, []string{}...)
+	return err
+}

--- a/pkg/storage/cstor_update.go
+++ b/pkg/storage/cstor_update.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (

--- a/pkg/storage/cstor_update.go
+++ b/pkg/storage/cstor_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/openebs/openebsctl/pkg/client"
 	"github.com/openebs/openebsctl/pkg/util"
@@ -60,4 +61,80 @@ func CSPCnodeChange(k *client.K8sClient, poolName, oldNode, newNode string) erro
 	_, err = k.OpenebsCS.CstorV1().CStorPoolClusters(k.Ns).Patch(context.TODO(), poolName,
 		types.MergePatchType, data, metav1.PatchOptions{}, []string{}...)
 	return err
+}
+
+// DebugCSPCNode returns the appropriate storage node for the cspc's nodes in a
+// map[InitialNode->FinalNode] manner and/or an error
+func DebugCSPCNode(k *client.K8sClient, cspc string) (map[string]string, error) {
+	// 1. Get the CSPC
+	pool, err := k.GetCSPC(cspc)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cspc %s, %v", cspc, err)
+	}
+	// 2. Get the hostnames with the BDs
+	expectedBDToHost := make(map[string]string)
+	var devices []string
+	for _, specs := range pool.Spec.Pools {
+		host := specs.NodeSelector["kubernetes.io/hostname"]
+		for _, rgs := range specs.DataRaidGroups {
+			for _, bds := range rgs.CStorPoolInstanceBlockDevices {
+				expectedBDToHost[bds.BlockDeviceName] = host
+				devices = append(devices, bds.BlockDeviceName)
+			}
+		}
+	}
+	// 3. Fetch all the BDs
+	bds, err := k.GetBDs(devices, "")
+	actualBDToHost := make(map[string]string)
+	for _, bd := range bds.Items {
+		actualBDToHost[bd.Name] = bd.Labels["kubernetes.io/hostname"]
+	}
+
+	if len(expectedBDToHost) != len(actualBDToHost) {
+		diff := len(expectedBDToHost) - len(actualBDToHost)
+		return nil, fmt.Errorf("%d blockdevices are missing from the cluster", diff)
+	}
+	// 4. Get the BD map difference
+	if reflect.DeepEqual(expectedBDToHost, actualBDToHost) {
+		return nil, fmt.Errorf("no change in the storage node")
+	}
+	// AWESOME: This piece of code can also handle circular node changes,
+	// the patching function would need some more work to handle this case,
+	// which is why this has been restricted to single node swaps
+
+	// 5. Calculate the difference, map expectedHost to the current host to
+	// help the existing function for swapping the node-selector values for
+	// the CSPCnodeChange function
+
+	diff := make(map[string]string)
+	for bd, presentHostForBD := range actualBDToHost {
+		if expectedHost, ok := expectedBDToHost[bd]; ok {
+			if expectedHost != presentHostForBD {
+				// difference spotted
+				if _, found := diff[expectedHost]; !found {
+					// add the difference to the map
+					diff[expectedHost] = presentHostForBD
+				} else if diff[expectedHost] != presentHostForBD {
+					// beyond the scope of this project
+					return nil, fmt.Errorf("multiple bds have switched to different nodes")
+				}
+			}
+			// do nothing if the host is same in expectation & present reality
+		}
+	}
+	// 5.1. Currently, the caller isn't supposed to be dealing with multiple
+	// node changes
+
+	// CHALLENGE: This logic will not work for if a multi-BD
+	// RAIDGroup's devices have moved to different nodes, in this case,
+	// the BlockDevices need to be moved from the current node to another
+	// node via an appropriate external tool, later this tool might offer
+	// suggestions for the same
+	if len(diff) > 1 {
+		return nil, fmt.Errorf("more than one node change in the storage instance")
+	}
+	// 6. Return the diff
+	// NOTE: While this is a legit error that the nodes in CSPC and in reality
+	// aren't in sync, it is a bad practice to return a usable value with a non-nil error
+	return diff, nil
 }

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -71,36 +71,33 @@ func TestCSPCnodeChange(t *testing.T) {
 			k: &client.K8sClient{
 				Ns:        "openebs",
 				K8sCS:     fake.NewSimpleClientset(&node2),
-				OpenebsCS: fakecstor.NewSimpleClientset(),
+				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 			},
-			poolName: "fake-pool",
-			oldNode:  "node1",
-			newNode:  "node2",
-		},
-		true},
+			poolName: "cassandra-pool", oldNode:  "node1",	newNode:  "node2"},true},
 		{"CSPC found, but newNode does not exist", args{
 			k: &client.K8sClient{
 				Ns:        "openebs",
 				K8sCS:     fake.NewSimpleClientset(&goodNode),
-				OpenebsCS: fakecstor.NewSimpleClientset(),
+				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 			},
-			poolName: "fake-pool",
-			oldNode:  "node3",
-			newNode:  "node-456",
-		},
-		true},
+			poolName: "cassandra-pool",	oldNode: "node3", newNode: "node-456"},true},
 		{
-			"CSPC found, newNode exists and is ready", args{
+			"CSPC found, newNode exists and is ready but old-node name does not match", args{
 				k: &client.K8sClient{
 					Ns: "openebs",
 					K8sCS: fake.NewSimpleClientset(&goodNode),
 					OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 				},
-				poolName: "cassandra-pool",
-				oldNode: "bad-node",
-				newNode: "node1",
+				poolName: "cassandra-pool",	oldNode: "bad-node",newNode: "node1"},false,
 		},
-		false,
+		{
+			"CSPC found, newNode exists and is ready, old-node name matches", args{
+			k: &client.K8sClient{
+				Ns: "openebs",
+				K8sCS: fake.NewSimpleClientset(&goodNode),
+				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
+			},
+			poolName: "cassandra-pool",	oldNode: "bad-node",newNode: "node1"},false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -225,8 +225,9 @@ func TestDebugCSPCNode(t *testing.T) {
 			fmt.Errorf(`no change in the storage node`)},
 		// it'd make sense to evaluate the error in the above Test suite somehow
 		{"CSPC exists, two BD's loc changed to other node", args{
-			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc2, &goodBD1N1, &goodBD2N1, &goodBD1N2, &goodBD2N2)}, cspc: "cspc1"},
-			map[string]string{"node2": "node3"}, false, nil},
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc2, &goodBD1N1, &goodBD2N1,
+				&goodBD1N2, &goodBD2N2)}, cspc: "cspc1"},
+			map[string]string{"node3": "node2"}, false, nil},
 		{"CSPC exists, BD nodes swapped", args{
 			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc3, &goodBD1N1, &goodBD2N1,
 				&goodBD1N2, &goodBD2N2)}, cspc: "cspc1"}, nil, true,

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -129,6 +129,7 @@ func TestCSPCnodeChange(t *testing.T) {
 	}
 }
 
+
 var cspc1 = cstorv1.CStorPoolCluster{
 	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "cspc1", Namespace: "openebs"},
@@ -186,21 +187,6 @@ var goodBD2N2 = v1alpha1.BlockDevice{
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
 
-var badBD1N2 = v1alpha1.BlockDevice{
-	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
-	ObjectMeta: metav1.ObjectMeta{Name: "bd1n2", Namespace: "openebs",
-		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
-	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
-		Path: "/dev/sda"},
-	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
-var badBD2N2 = v1alpha1.BlockDevice{
-	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
-	ObjectMeta: metav1.ObjectMeta{Name: "bd2n2", Namespace: "openebs",
-		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
-	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
-		Path: "/dev/sda"},
-	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
-
 var cspc3 = cstorv1.CStorPoolCluster{
 	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "cspc1", Namespace: "openebs"},
@@ -239,7 +225,7 @@ func TestDebugCSPCNode(t *testing.T) {
 			fmt.Errorf(`no change in the storage node`)},
 		// it'd make sense to evaluate the error in the above Test suite somehow
 		{"CSPC exists, two BD's loc changed to other node", args{
-			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc1, &goodBD1N1, &goodBD2N1, &badBD1N2, &badBD2N2)}, cspc: "cspc1"},
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc2, &goodBD1N1, &goodBD2N1, &goodBD1N2, &goodBD2N2)}, cspc: "cspc1"},
 			map[string]string{"node2": "node3"}, false, nil},
 		{"CSPC exists, BD nodes swapped", args{
 			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc3, &goodBD1N1, &goodBD2N1,

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package storage
 
 import (
@@ -35,7 +51,7 @@ var node2 = corev1.Node{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "node2"},
 	Status: corev1.NodeStatus{Phase: corev1.NodePending,
-	Conditions: []corev1.NodeCondition{
+		Conditions: []corev1.NodeCondition{
 			{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
 			{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
 			{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
@@ -64,8 +80,8 @@ func TestCSPCnodeChange(t *testing.T) {
 			poolName: "fake-pool",
 			oldNode:  "node1",
 			newNode:  "node2",
-			},
-		true,
+		},
+			true,
 		},
 		{"CSPC found, but newNode is not ready", args{
 			k: &client.K8sClient{
@@ -73,31 +89,31 @@ func TestCSPCnodeChange(t *testing.T) {
 				K8sCS:     fake.NewSimpleClientset(&node2),
 				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 			},
-			poolName: "cassandra-pool", oldNode:  "node1",	newNode:  "node2"},true},
+			poolName: "cassandra-pool", oldNode: "node1", newNode: "node2"}, true},
 		{"CSPC found, but newNode does not exist", args{
 			k: &client.K8sClient{
 				Ns:        "openebs",
 				K8sCS:     fake.NewSimpleClientset(&goodNode),
 				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 			},
-			poolName: "cassandra-pool",	oldNode: "node3", newNode: "node-456"},true},
+			poolName: "cassandra-pool", oldNode: "node3", newNode: "node-456"}, true},
 		{
 			"CSPC found, newNode exists and is ready but old-node name does not match", args{
 				k: &client.K8sClient{
-					Ns: "openebs",
-					K8sCS: fake.NewSimpleClientset(&goodNode),
+					Ns:        "openebs",
+					K8sCS:     fake.NewSimpleClientset(&goodNode),
 					OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
 				},
-				poolName: "cassandra-pool",	oldNode: "bad-node",newNode: "node1"},false,
+				poolName: "cassandra-pool", oldNode: "bad-node", newNode: "node1"}, false,
 		},
 		{
 			"CSPC found, newNode exists and is ready, old-node name matches", args{
-			k: &client.K8sClient{
-				Ns: "openebs",
-				K8sCS: fake.NewSimpleClientset(&goodNode),
-				OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
-			},
-			poolName: "cassandra-pool",	oldNode: "bad-node",newNode: "node1"},false,
+				k: &client.K8sClient{
+					Ns:        "openebs",
+					K8sCS:     fake.NewSimpleClientset(&goodNode),
+					OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
+				},
+				poolName: "cassandra-pool", oldNode: "bad-node", newNode: "node1"}, false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -1,0 +1,113 @@
+package storage
+
+import (
+	"testing"
+
+	fakecstor "github.com/openebs/api/v2/pkg/client/clientset/versioned/fake"
+	"github.com/openebs/openebsctl/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var goodNode = corev1.Node{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Node",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "node1"},
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning,
+		Conditions: []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionFalse},
+		},
+	}}
+
+var node2 = corev1.Node{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Node",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "node2"},
+	Status: corev1.NodeStatus{Phase: corev1.NodePending,
+	Conditions: []corev1.NodeCondition{
+			{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionTrue},
+			{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodePIDPressure, Status: corev1.ConditionFalse},
+			{Type: corev1.NodeNetworkUnavailable, Status: corev1.ConditionFalse},
+		}},
+}
+
+func TestCSPCnodeChange(t *testing.T) {
+	type args struct {
+		k        *client.K8sClient
+		poolName string
+		oldNode  string
+		newNode  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{"No cspc found", args{
+			k: &client.K8sClient{
+				Ns:        "openebs",
+				OpenebsCS: fakecstor.NewSimpleClientset(),
+			},
+			poolName: "fake-pool",
+			oldNode:  "node1",
+			newNode:  "node2",
+			},
+		true,
+		},
+		{"CSPC found, but newNode is not ready", args{
+			k: &client.K8sClient{
+				Ns:        "openebs",
+				K8sCS:     fake.NewSimpleClientset(&node2),
+				OpenebsCS: fakecstor.NewSimpleClientset(),
+			},
+			poolName: "fake-pool",
+			oldNode:  "node1",
+			newNode:  "node2",
+		},
+		true},
+		{"CSPC found, but newNode does not exist", args{
+			k: &client.K8sClient{
+				Ns:        "openebs",
+				K8sCS:     fake.NewSimpleClientset(&goodNode),
+				OpenebsCS: fakecstor.NewSimpleClientset(),
+			},
+			poolName: "fake-pool",
+			oldNode:  "node3",
+			newNode:  "node-456",
+		},
+		true},
+		{
+			"CSPC found, newNode exists and is ready", args{
+				k: &client.K8sClient{
+					Ns: "openebs",
+					K8sCS: fake.NewSimpleClientset(&goodNode),
+					OpenebsCS: fakecstor.NewSimpleClientset(&cspc),
+				},
+				poolName: "cassandra-pool",
+				oldNode: "bad-node",
+				newNode: "node1",
+		},
+		false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CSPCnodeChange(tt.args.k, tt.args.poolName, tt.args.oldNode, tt.args.newNode); (err != nil) != tt.wantErr {
+				t.Errorf("CSPCnodeChange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/storage/cstor_update_test.go
+++ b/pkg/storage/cstor_update_test.go
@@ -17,8 +17,12 @@ limitations under the License.
 package storage
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
 	fakecstor "github.com/openebs/api/v2/pkg/client/clientset/versioned/fake"
 	"github.com/openebs/openebsctl/pkg/client"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +124,142 @@ func TestCSPCnodeChange(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := CSPCnodeChange(tt.args.k, tt.args.poolName, tt.args.oldNode, tt.args.newNode); (err != nil) != tt.wantErr {
 				t.Errorf("CSPCnodeChange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+var cspc1 = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "cspc1", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+		DataRaidGroups: []cstorv1.RaidGroup{{
+			CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n1"}, {BlockDeviceName: "bd2n1"}}}},
+		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
+			DataRaidGroups: []cstorv1.RaidGroup{{
+				CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n2"}, {BlockDeviceName: "bd2n2"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}},
+}
+
+var cspc2 = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "cspc1", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+		DataRaidGroups: []cstorv1.RaidGroup{{
+			CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n1"}, {BlockDeviceName: "bd2n1"}}}},
+		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node3"},
+			DataRaidGroups: []cstorv1.RaidGroup{{
+				CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n2"}, {BlockDeviceName: "bd2n2"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}},
+}
+
+var goodBD1N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD2N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD1N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD2N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var badBD1N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var badBD2N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var cspc3 = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "cspc1", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
+		DataRaidGroups: []cstorv1.RaidGroup{{
+			CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n1"}, {BlockDeviceName: "bd2n1"}}}},
+		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+			DataRaidGroups: []cstorv1.RaidGroup{{
+				CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1n2"}, {BlockDeviceName: "bd2n2"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}},
+}
+
+func TestDebugCSPCNode(t *testing.T) {
+	type args struct {
+		k    *client.K8sClient
+		cspc string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+		err     error
+	}{
+		{"unable to find CSPC", args{k: &client.K8sClient{
+			Ns: "random", OpenebsCS: fakecstor.NewSimpleClientset()}, cspc: "cspc1"}, nil, true,
+			fmt.Errorf(`unable to get cspc cspc1, Error while getting cspc: cstorpoolclusters.cstor.openebs.io "cspc1" not found`)},
+		{"CSPC exists, not in the guessed namespace so unable to find it", args{
+			k: &client.K8sClient{Ns: "wrongNS", OpenebsCS: fakecstor.NewSimpleClientset(&cspc1)}, cspc: "cspc1"}, nil, true,
+			fmt.Errorf(`unable to get cspc cspc1, Error while getting cspc: cstorpoolclusters.cstor.openebs.io "cspc1" not found`)},
+		{"CSPC exists, blockdevices are in the same node as expected", args{
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc1, &goodBD1N1, &goodBD2N1,
+				&goodBD1N2, &goodBD2N2)}, cspc: "cspc1"}, nil, true,
+			fmt.Errorf(`no change in the storage node`)},
+		// it'd make sense to evaluate the error in the above Test suite somehow
+		{"CSPC exists, two BD's loc changed to other node", args{
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc1, &goodBD1N1, &goodBD2N1, &badBD1N2, &badBD2N2)}, cspc: "cspc1"},
+			map[string]string{"node2": "node3"}, false, nil},
+		{"CSPC exists, BD nodes swapped", args{
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc3, &goodBD1N1, &goodBD2N1,
+				&goodBD1N2, &goodBD2N2)}, cspc: "cspc1"}, nil, true,
+			fmt.Errorf(`more than one node change in the storage instance`)},
+		{"CSPC exists, all 4 BDs are missing", args{
+			k: &client.K8sClient{Ns: "openebs", OpenebsCS: fakecstor.NewSimpleClientset(&cspc3)}, cspc: "cspc1"}, nil, true,
+			fmt.Errorf("%d blockdevices are missing from the cluster", 4)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DebugCSPCNode(tt.args.k, tt.args.cspc)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DebugCSPCNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			} else if err != nil && !reflect.DeepEqual(err.Error(), tt.err.Error()) {
+				t.Logf("DebugCSPCNode() Got %v error, wanted %v error", err, tt.err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DebugCSPCNode() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -149,9 +149,9 @@ func Update(namespace, storageName, initial, final string) error {
 	if namespace == "" {
 		ns, err := k.GetOpenEBSNamespace(util.CstorCasType)
 		k.Ns = ns
-	if err != nil {
+		if err != nil {
 			return fmt.Errorf("unable to detect cstor, please specify cstor's --openebs-namespace")
-	}
+		}
 	}
 	return CSPCnodeChange(k, storageName, initial, final)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -141,3 +141,17 @@ func CasDescribeMap() map[string]func(*client.K8sClient, string) error {
 func CasDescribeList() []func(*client.K8sClient, string) error {
 	return []func(*client.K8sClient, string) error{DescribeCstorPool, DescribeZFSNode, DescribeLVMvg}
 }
+
+// Update is the entrypoint to manage the Update of storage resources of a particular cas-type
+func Update(namespace, storageName, initial, final string) error {
+	// 1. Currently only Cstor's node patch is supported
+	k, _ := client.NewK8sClient(namespace)
+	if namespace == "" {
+		ns, err := k.GetOpenEBSNamespace(util.CstorCasType)
+		k.Ns = ns
+	if err != nil {
+			return fmt.Errorf("unable to detect cstor, please specify cstor's --openebs-namespace")
+	}
+	}
+	return CSPCnodeChange(k, storageName, initial, final)
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -145,7 +145,7 @@ func CasDescribeList() []func(*client.K8sClient, string) error {
 // Update is the entrypoint to manage the Update of storage resources of a particular cas-type
 func Update(namespace, storageName, initial, final string) error {
 	// 1. Currently only Cstor's node patch is supported
-	k, _ := client.NewK8sClient(namespace)
+	k := client.NewK8sClient(namespace)
 	if namespace == "" {
 		ns, err := k.GetOpenEBSNamespace(util.CstorCasType)
 		k.Ns = ns

--- a/pkg/storage/testdata_test.go
+++ b/pkg/storage/testdata_test.go
@@ -35,14 +35,14 @@ var (
 		TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "cassandra-pool", Namespace: "openebs"},
 		Spec: v1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
-			NodeSelector: map[string]string{"kubernetes.io/node-name": "bad-node"},
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "bad-node"},
 			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []v1.CStorPoolInstanceBlockDevice{
 				{BlockDeviceName: "bd-1", Capacity: 1234, DevLink: "/dev/bd-1"}}}},
 			WriteCacheRaidGroups: nil,
 			PoolConfig:           v1.PoolConfig{DataRaidGroupType: "stripe"},
 		},
 			{
-				NodeSelector: map[string]string{"kubernetes.io/node-name": "good-node"},
+				NodeSelector: map[string]string{"kubernetes.io/hostname": "good-node"},
 				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []v1.CStorPoolInstanceBlockDevice{
 					{BlockDeviceName: "bd-2", Capacity: 1234, DevLink: "/dev/bd-2"}}}},
 				WriteCacheRaidGroups: nil,

--- a/pkg/storage/testdata_test.go
+++ b/pkg/storage/testdata_test.go
@@ -30,6 +30,30 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	cspc = cstorv1.CStorPoolCluster{
+		TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "cassandra-pool", Namespace: "openebs"},
+		Spec: v1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+			NodeSelector: map[string]string{"kubernetes.io/node-name": "bad-node"},
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []v1.CStorPoolInstanceBlockDevice{
+				{BlockDeviceName: "bd-1", Capacity: 1234, DevLink: "/dev/bd-1"}}}},
+			WriteCacheRaidGroups: nil,
+			PoolConfig:           v1.PoolConfig{DataRaidGroupType: "stripe"},
+		},
+			{
+				NodeSelector: map[string]string{"kubernetes.io/node-name": "good-node"},
+				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []v1.CStorPoolInstanceBlockDevice{
+					{BlockDeviceName: "bd-2", Capacity: 1234, DevLink: "/dev/bd-2"}}}},
+				WriteCacheRaidGroups: nil,
+				PoolConfig:           v1.PoolConfig{DataRaidGroupType: "stripe"},
+			}},
+		},
+		Status:         v1.CStorPoolClusterStatus{},
+		VersionDetails: v1.VersionDetails{},
+	}
+)
+
 var cspi1 = cstorv1.CStorPoolInstance{
 	TypeMeta: metav1.TypeMeta{Kind: "CStorPoolInstance", APIVersion: "cstor.openebs.io/v1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "openebs",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -177,9 +177,8 @@ func GetUsedPercentage(total string, used string) float64 {
 func ColorStringOnStatus(stringToColor string) string {
 	if strings.Contains(stringsToBeColoredGreen, strings.ToLower(stringToColor)) {
 		return ColorText(stringToColor, Green)
-	} else {
-		return ColorText(stringToColor, Red)
 	}
+	return ColorText(stringToColor, Red)
 }
 
 // PromptToStartAgain opens prompt and waits for the user for response

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/manifoldco/promptui"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -203,5 +204,17 @@ func PromptToStartAgain(label string, defaultOption bool) bool {
 		return true
 	}
 
+	return false
+}
+
+// IsNodeReady returns true if the node is ready
+func IsNodeReady(node *corev1.Node) bool {
+	if node != nil && len(node.Status.Conditions) > 0 {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady {
+				return condition.Status == corev1.ConditionTrue
+			}
+		}
+	}
 	return false
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -19,6 +19,8 @@ package util
 import (
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestDuration(t *testing.T) {
@@ -208,6 +210,31 @@ func TestGetAvailableCapacity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetAvailableCapacity(tt.args.total, tt.args.used); got != tt.want {
 				t.Errorf("GetAvailableCapacity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNodeReady(t *testing.T) {
+	type args struct {
+		node *corev1.Node
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"node is ready", args{&corev1.Node{Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type:   corev1.NodeReady, Status: corev1.ConditionTrue}}} }}, true},
+		{"node is not ready", args{&corev1.Node{Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type:   corev1.NodeReady, Status: corev1.ConditionFalse}}} }}, false},
+		{"node has PID pressure, Ready status not known", args{&corev1.Node{Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type:   corev1.NodePIDPressure, Status: corev1.ConditionTrue}}} }}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNodeReady(tt.args.node); got != tt.want {
+				t.Errorf("IsNodeReady() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -225,11 +225,11 @@ func TestIsNodeReady(t *testing.T) {
 		want bool
 	}{
 		{"node is ready", args{&corev1.Node{Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{Type:   corev1.NodeReady, Status: corev1.ConditionTrue}}} }}, true},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}}}}}, true},
 		{"node is not ready", args{&corev1.Node{Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{Type:   corev1.NodeReady, Status: corev1.ConditionFalse}}} }}, false},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionFalse}}}}}, false},
 		{"node has PID pressure, Ready status not known", args{&corev1.Node{Status: corev1.NodeStatus{
-			Conditions: []corev1.NodeCondition{{Type:   corev1.NodePIDPressure, Status: corev1.ConditionTrue}}} }}, false},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodePIDPressure, Status: corev1.ConditionTrue}}}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# UX
```bash
➜  openebsctl git:(cstor_pool_move) ✗ kubectl -n openebs get cspc default-cstor-disk -oyaml | grep old
      kubernetes.io/hostname: old-node

# success case
➜  openebsctl git:(cstor_pool_move) ✗ kubectl openebs update storage default-cstor-disk --from-node=old-node --to-node=minikube
➜  openebsctl git:(cstor_pool_move) ✗ echo $?                                                         
0
➜  openebsctl git:(cstor_pool_move) ✗ kubectl -n openebs get cspc default-cstor-disk -oyaml | grep old
# the old-node has been changed to `minikube` node which is in Ready state after the successful patch operation

# failure case
➜  openebsctl git:(cstor_pool_move) ✗ kubectl openebs update storage default-cstor-disk --from-node=minikube --to-node=dummynode 
node dummynode not found
```

# Questions

- Is the current command structure okay for this or should a `node` or a `pool-migrate` sub-command/word be inserted somewhere?
- Is it okay to put in some *more* small nifty tasks which **modify the state of the system** which the end user had to do it anyway(maybe with a more steady hand and after some thought & checks)?
- Is this implementation okay, considering the issue(#84) description clearly states that the CLI should provide the updated YAML? `Provide the user with an updated CSPC yaml with the required node selector change.`


fixes: #84
Co-authored-by: Shubham Bajpai (@shubham14bajpai) <shubham.bajpai@mayadata.io>
Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>
