### PR TITLE
feat(cluster-info): Add feature to show component versions, statuses and running components for each installed engine

### DIFF
--- a/cmd/cluster-info/cluster-info.go
+++ b/cmd/cluster-info/cluster-info.go
@@ -22,14 +22,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	clusterInfoCmdHelp = `Usage:
+  kubectl openebs cluster-info
+Flags:
+  -h, --help                           help for openebs get command
+`
+)
+
+
 // NewCmdClusterInfo shows OpenEBSCTL cluster-info
 func NewCmdClusterInfo(rootCmd *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster-info",
-		Short: "Show client version",
+		Short: "Show component version, status and running components for each installed engine",
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(cluster_info.ShowClusterInfo(), util.Fatal)
 		},
 	}
+	cmd.SetUsageTemplate(clusterInfoCmdHelp)
 	return cmd
 }

--- a/cmd/cluster-info/cluster-info.go
+++ b/cmd/cluster-info/cluster-info.go
@@ -14,31 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package get
+package cluster_info
 
 import (
-	"fmt"
-
+	cluster_info "github.com/openebs/openebsctl/pkg/cluster-info"
+	"github.com/openebs/openebsctl/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-const (
-	versionCmdHelp = `Usage:
-  kubectl openebs version
-Flags:
-  -h, --help                           help for openebs get command
-`
-)
-
-// NewCmdVersion shows OpenEBSCTL version
-func NewCmdVersion(rootCmd *cobra.Command) *cobra.Command {
+// NewCmdClusterInfo shows OpenEBSCTL cluster-info
+func NewCmdClusterInfo(rootCmd *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Shows openebs kubectl plugin's version",
+		Use:   "cluster-info",
+		Short: "Show client version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Client Version: " + rootCmd.Version)
+			util.CheckErr(cluster_info.ShowClusterInfo(), util.Fatal)
 		},
 	}
-	cmd.SetUsageTemplate(versionCmdHelp)
 	return cmd
 }

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"flag"
+	cluster_info "github.com/openebs/openebsctl/cmd/cluster-info"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,6 +79,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 		get.NewCmdGet(cmd),
 		describe.NewCmdDescribe(cmd),
 		v.NewCmdVersion(cmd),
+		cluster_info.NewCmdClusterInfo(cmd),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -35,11 +35,12 @@ const (
   kubectl openebs [command] [resource] [...names] [flags]
 
 Available Commands:
-  completion  Outputs shell completion code for the specified shell (bash or zsh)
-  describe    Provide detailed information about an OpenEBS resource
-  get         Provides fetching operations related to a Volume/Pool
-  help        Help about any command
-  version     Shows openebs kubectl plugin's version
+  completion    Outputs shell completion code for the specified shell (bash or zsh)
+  describe      Provide detailed information about an OpenEBS resource
+  get           Provides fetching operations related to a Volume/Pool
+  help          Help about any command
+  version       Shows openebs kubectl plugin's version
+  cluster-info  Show component version, status and running components for each installed engine
 
 Flags:
   -h, --help                           help for openebs

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -703,3 +703,11 @@ func (k K8sClient) GetEvents(fieldSelector string) (*corev1.EventList, error) {
 	}
 	return events, nil
 }
+
+func (k K8sClient) GetPods(labelSelector string, fieldSelector string, namespace string) (*corev1.PodList, error) {
+	pods, err := k.K8sCS.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
+	if err != nil {
+		return nil, fmt.Errorf("error getting pods : %v", err)
+	}
+	return pods, nil
+}

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -696,6 +696,7 @@ func (k K8sClient) GetCSIControllerSTS(name string) (*appsv1.StatefulSet, error)
 	}
 }
 
+// GetEvents returns the corev1 events based on the fieldSelectors
 func (k K8sClient) GetEvents(fieldSelector string) (*corev1.EventList, error) {
 	events, err := k.K8sCS.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{FieldSelector: fieldSelector})
 	if err != nil {
@@ -704,6 +705,7 @@ func (k K8sClient) GetEvents(fieldSelector string) (*corev1.EventList, error) {
 	return events, nil
 }
 
+// GetPods returns the corev1 Pods based on the label and field selectors
 func (k K8sClient) GetPods(labelSelector string, fieldSelector string, namespace string) (*corev1.PodList, error) {
 	pods, err := k.K8sCS.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
 	if err != nil {

--- a/pkg/cluster-info/cluster-info.go
+++ b/pkg/cluster-info/cluster-info.go
@@ -18,12 +18,13 @@ package cluster_info
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/openebs/openebsctl/pkg/client"
 	"github.com/openebs/openebsctl/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/printers"
-	"strings"
 )
 
 // ShowClusterInfo shows the openebs components and their status and versions
@@ -67,6 +68,7 @@ func getComponentDataByComponents(k *client.K8sClient, componentNames string, ca
 	if len(podList.Items) != 0 {
 		for _, item := range podList.Items {
 			if val, ok := componentDataMap[item.Labels["openebs.io/component-name"]]; ok {
+				// Update only if the status of the component is not running.
 				if val.Status != "Running" {
 					componentDataMap[item.Labels["openebs.io/component-name"]] = util.ComponentData{
 						Namespace: item.Namespace,
@@ -121,7 +123,7 @@ func getLocalPVDeviceStatus(componentDataMap map[string]util.ComponentData) (str
 
 func getVersion(componentDataMap map[string]util.ComponentData) string {
 	for key, val := range componentDataMap {
-		if !strings.Contains(util.NDMComponentNames, key) && val.Version != "" {
+		if !strings.Contains(util.NDMComponentNames, key) && val.Version != "" && val.Status == "Running"{
 			return val.Version
 		}
 	}

--- a/pkg/cluster-info/cluster-info.go
+++ b/pkg/cluster-info/cluster-info.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster_info
+
+import (
+	"fmt"
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/printers"
+	"strings"
+)
+
+// ShowClusterInfo shows the openebs components and their status and versions
+func ShowClusterInfo() error {
+	k, _ := client.NewK8sClient("")
+	var clusterInfoRows []metav1.TableRow
+	for casType, componentNames := range util.CasTypeToComponentNamesMap {
+		componentDataMap, _ := getComponentDataByComponents(k, componentNames, casType)
+		if len(componentDataMap) != 0 {
+			status, working := "", ""
+			if casType == util.LocalDeviceCasType {
+				var err error
+				status, working, err = getLocalPVDeviceStatus(componentDataMap)
+				if err != nil {
+					continue
+				}
+			} else {
+				status, working = getStatus(componentDataMap)
+			}
+			version := getVersion(componentDataMap)
+			namespace := getNamespace(componentDataMap)
+			clusterInfoRows = append(
+				clusterInfoRows,
+				metav1.TableRow{Cells: []interface{}{casType, namespace, version, working, util.ColorStringOnStatus(status)}},
+			)
+		}
+	}
+	if len(clusterInfoRows) == 0 {
+		fmt.Println("None Of the OpenEBS Storage Engines are installed in this cluster")
+	} else {
+		util.TablePrinter(util.ClusterInfoColumnDefinitions, clusterInfoRows, printers.PrintOptions{})
+	}
+	return nil
+}
+
+func getComponentDataByComponents(k *client.K8sClient, componentNames string, casType string) (map[string]util.ComponentData, error) {
+	var podList *corev1.PodList
+	// Fetch Cstor Components
+	componentDataMap := make(map[string]util.ComponentData)
+	podList, _ = k.GetPods(fmt.Sprintf("openebs.io/component-name in (%s)", componentNames), "", "")
+	if len(podList.Items) != 0 {
+		for _, item := range podList.Items {
+			if val, ok := componentDataMap[item.Labels["openebs.io/component-name"]]; ok {
+				if val.Status != "Running" {
+					componentDataMap[item.Labels["openebs.io/component-name"]] = util.ComponentData{
+						Namespace: item.Namespace,
+						Status:    string(item.Status.Phase),
+						Version:   item.Labels["openebs.io/version"],
+						CasType:   casType,
+					}
+				}
+			} else {
+				componentDataMap[item.Labels["openebs.io/component-name"]] = util.ComponentData{
+					Namespace: item.Namespace,
+					Status:    string(item.Status.Phase),
+					Version:   item.Labels["openebs.io/version"],
+					CasType:   casType,
+				}
+			}
+		}
+		return componentDataMap, nil
+	} else {
+		return nil, fmt.Errorf("components for %s engine are not installed", casType)
+	}
+}
+
+func getStatus(componentDataMap map[string]util.ComponentData) (string, string) {
+	totalComponents := len(componentDataMap)
+	healthyComponents := 0
+	for _, val := range componentDataMap {
+		if val.Status == "Running" {
+			healthyComponents += 1
+		}
+	}
+	if healthyComponents == totalComponents {
+		return "Healthy", fmt.Sprintf("%d/%d", healthyComponents, totalComponents)
+	} else if healthyComponents < totalComponents {
+		return "Degraded", fmt.Sprintf("%d/%d", healthyComponents, totalComponents)
+	} else {
+		return "Unhealthy", fmt.Sprintf("%d/%d", 0, totalComponents)
+	}
+}
+
+func getLocalPVDeviceStatus(componentDataMap map[string]util.ComponentData) (string, string, error) {
+	if ndmData, ok := componentDataMap["ndm"]; ok {
+		if localPVData, ok := componentDataMap["openebs-localpv-provisioner"]; ok {
+			if ndmData.Namespace == localPVData.Namespace {
+				status, working := getStatus(componentDataMap)
+				return status, working, nil
+			}
+		}
+	}
+	return "", "", fmt.Errorf("installed NDM is not for Device LocalPV")
+}
+
+func getVersion(componentDataMap map[string]util.ComponentData) string {
+	for key, val := range componentDataMap {
+		if !strings.Contains(util.NDMComponentNames, key) && val.Version != "" {
+			return val.Version
+		}
+	}
+	return ""
+}
+
+func getNamespace(componentDataMap map[string]util.ComponentData) string {
+	for key, val := range componentDataMap {
+		if !strings.Contains(util.NDMComponentNames, key) && val.Namespace != "" {
+			return val.Namespace
+		}
+	}
+	return ""
+}

--- a/pkg/cluster-info/cluster-info.go
+++ b/pkg/cluster-info/cluster-info.go
@@ -53,7 +53,7 @@ func ShowClusterInfo() error {
 		}
 	}
 	if len(clusterInfoRows) == 0 {
-		fmt.Println("None Of the OpenEBS Storage Engines are installed in this cluster")
+		return fmt.Errorf("none Of the OpenEBS Storage Engines are installed in this cluster")
 	} else {
 		util.TablePrinter(util.ClusterInfoColumnDefinitions, clusterInfoRows, printers.PrintOptions{})
 	}

--- a/pkg/cluster-info/cluster-info_test.go
+++ b/pkg/cluster-info/cluster-info_test.go
@@ -1,0 +1,22 @@
+package cluster_info
+
+import "testing"
+
+func TestShowClusterInfo(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr bool
+	}{
+		{
+			"Test 1",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ShowClusterInfo(); (err != nil) != tt.wantErr {
+				t.Errorf("ShowClusterInfo() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/cluster-info/cluster-info_test.go
+++ b/pkg/cluster-info/cluster-info_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cluster_info
 
 import "testing"

--- a/pkg/cluster-info/cluster-info_test.go
+++ b/pkg/cluster-info/cluster-info_test.go
@@ -7,10 +7,7 @@ func TestShowClusterInfo(t *testing.T) {
 		name    string
 		wantErr bool
 	}{
-		{
-			"Test 1",
-			false,
-		},
+		{},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -33,6 +33,10 @@ const (
 	JivaCasType = "jiva"
 	// LVMCasType cas type name
 	LVMCasType = "localpv-lvm"
+	// LocalHostpathCasType cas type name
+	LocalHostpathCasType = "localpv-hostpath"
+	// LocalDeviceCasType cas type name
+	LocalDeviceCasType = "localpv-device"
 	// Healthy cstor volume status
 	Healthy = "Healthy"
 	// StorageKey key present in pvc status.capacity
@@ -77,6 +81,15 @@ const (
 	ZFSLocalPVcsiControllerLabelValue = "openebs-zfs-controller"
 )
 
+const (
+	CstorComponentNames    = "cspc-operator,cvc-operator,cstor-admission-webhook,openebs-cstor-csi-node,openebs-cstor-csi-controller"
+	NDMComponentNames      = "openebs-ndm-operator,ndm"
+	JivaComponentNames     = "openebs-jiva-csi-node,openebs-jiva-csi-controller,openebs-localpv-provisioner,jiva-operator"
+	LVMComponentNames      = "openebs-lvm-controller,openebs-lvm-node"
+	ZFSComponentNames      = "openebs-zfs-controller,openebs-zfs-node"
+	HostpathComponentNames = "openebs-localpv-provisioner"
+)
+
 var (
 	// CasTypeAndComponentNameMap stores the component name of the corresponding cas type
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
@@ -102,6 +115,16 @@ var (
 		LocalPVLVMCSIDriver: LVMCasType,
 		ZFSCSIDriver:        ZFSCasType,
 	}
+
+	CasTypeToComponentNamesMap = map[string]string{
+		CstorCasType:         CstorComponentNames + "," + NDMComponentNames,
+		JivaCasType:          JivaComponentNames,
+		LocalHostpathCasType: HostpathComponentNames,
+		LocalDeviceCasType:   HostpathComponentNames + "," + NDMComponentNames,
+		ZFSCasType:           ZFSComponentNames,
+		LVMCasType:           LVMComponentNames,
+	}
+
 	// CstorReplicaColumnDefinations stores the Table headers for CVR Details
 	CstorReplicaColumnDefinations = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
@@ -245,5 +268,14 @@ var (
 		{Name: "Reason", Type: "string"},
 		{Name: "Message", Type: "string"},
 		{Name: "Type", Type: "string"},
+	}
+	// ClusterInfoColumnDefinitions stores the Table headers for Cluster-Info details
+	ClusterInfoColumnDefinitions = []metav1.TableColumnDefinition{
+		{Name: "Cas-Type", Type: "string"},
+		{Name: "Namespace", Type: "string"},
+		{Name: "Version", Type: "string"},
+		{Name: "Working", Type: "string"},
+		{Name: "Status", Type: "string"},
+
 	}
 )

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -82,11 +82,17 @@ const (
 )
 
 const (
+	// CstorComponentNames for the cstor control plane components
 	CstorComponentNames    = "cspc-operator,cvc-operator,cstor-admission-webhook,openebs-cstor-csi-node,openebs-cstor-csi-controller"
+	// NDMComponentNames for the ndm components
 	NDMComponentNames      = "openebs-ndm-operator,ndm"
+	// JivaComponentNames for the jiva control plane components
 	JivaComponentNames     = "openebs-jiva-csi-node,openebs-jiva-csi-controller,openebs-localpv-provisioner,jiva-operator"
+	// LVMComponentNames for the lvm control plane components
 	LVMComponentNames      = "openebs-lvm-controller,openebs-lvm-node"
+	// ZFSComponentNames for the zfs control plane components
 	ZFSComponentNames      = "openebs-zfs-controller,openebs-zfs-node"
+	// HostpathComponentNames for the hostpath control plane components
 	HostpathComponentNames = "openebs-localpv-provisioner"
 )
 

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -116,6 +116,8 @@ var (
 		ZFSCSIDriver:        ZFSCasType,
 	}
 
+	// CasTypeToComponentNamesMap stores the names of the control-plane components of each cas-types.
+	// To show statuses of new CasTypes, please update this map.
 	CasTypeToComponentNamesMap = map[string]string{
 		CstorCasType:         CstorComponentNames + "," + NDMComponentNames,
 		JivaCasType:          JivaComponentNames,
@@ -276,6 +278,5 @@ var (
 		{Name: "Version", Type: "string"},
 		{Name: "Working", Type: "string"},
 		{Name: "Status", Type: "string"},
-
 	}
 )

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -262,3 +262,10 @@ type LVMVolDesc struct {
 	ThinProvisioned string
 	NodeID          string
 }
+
+type ComponentData struct {
+	Namespace string
+	Status string
+	Version string
+	CasType string
+}

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -263,6 +263,7 @@ type LVMVolDesc struct {
 	NodeID          string
 }
 
+// ComponentData stores the data for each component of an engine
 type ComponentData struct {
 	Namespace string
 	Status string


### PR DESCRIPTION
### What does this PR do?
- This PR adds the `cluster-info` command to show the control-plane version and status.
- This adds the template to add any `cas-type` to this command.
- The `WORKING` column shows the number of control-plane components running vs no. of components should be Running.

### Usage and Output
```
$ kubectl openebs cluster-info
```  
![Screenshot from 2021-08-30 11-07-38](https://user-images.githubusercontent.com/32007083/131291870-fca527e9-edc1-4e7c-8c7a-ecbdb592b4e5.png)

Closes #36 