### PR TITLE
feat(pvc describe): Add support to describe LVM and ZFS PVCs

### DIFF
--- a/docs/localpv-lvm/README.md
+++ b/docs/localpv-lvm/README.md
@@ -8,6 +8,7 @@
     * [Get LocalPV-LVM VolumeGroups](#get-localpv-lvm-volumegroups)
     * [Describe LocalPV-LVM volumeGroups](#describe-localpv-lvm-volumeGroups)
     * [Describe LocalPV-LVM volumes](#describe-localpv-lvm-volumes)
+    * [Describe LocalPV-LVM PVCs](#describe-localpv-lvm-pvcs)
 
 * #### `LocalPV-LVM`
     * #### Get `LocalPV-LVM` volumes
@@ -68,3 +69,34 @@
       ThinProvisioned : no
       NodeID          : worker-sh1
       ```
+    * #### Describe `LocalPV-LVM` PVCs
+      ```bash
+      $ kubectl openebs describe pvc csi-lvmpv
+      
+      csi-lvmpv Details  :
+      -------------------
+      NAME               : csi-lvmpv
+      NAMESPACE          : default
+      CAS TYPE           : localpv-lvm
+      BOUND VOLUME       : pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8
+      STORAGE CLASS      : openebs-lvmpv
+      SIZE               : 4Gi
+      PVC STATUS         : Bound
+      
+      pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8 Details :
+      ------------------
+      NAME              : pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8
+      NAMESPACE         : localpv-lvm
+      ACCESS MODE       : ReadWriteOnce
+      CSI DRIVER        : local.csi.openebs.io
+      CAPACITY          : 4Gi
+      PVC NAME          : csi-lvmpv
+      VOLUME PHASE      : Bound
+      STORAGE CLASS     : openebs-lvmpv
+      VERSION           : 0.8.0
+      LVM VOLUME STATUS : Ready
+      VOLUME GROUP      : lvmvg
+      SHARED            : no
+      THIN PROVISIONED  : no
+      NODE ID           : node1-virtual-machine
+      ``` 

--- a/docs/localpv-zfs/README.md
+++ b/docs/localpv-zfs/README.md
@@ -8,6 +8,7 @@
     * [Get LocalPV-ZFS Pools](#get-localpv-zfs-pools)
     * [Describe LocalPV-ZFS volumes](#describe-localpv-zfs-volumes)
     * [Describe LocalPV-ZFS pools](#describe-localpv-zfs-pools)
+    * [Describe LocalPV-ZFS PVCs](#describe-localpv-zfs-pvcs)
   
 * #### `LocalPV-ZFS`
     * #### Get `LocalPV-ZFS` volumes
@@ -51,7 +52,7 @@
       NodeID        : worker-sh1
       Recordsize    : 4k
       ```
-    * #### Describe `LocalPV-ZFS pools`
+    * #### Describe `LocalPV-ZFS` pools
       ```bash
       $ kubectl openebs describe storage node2
     
@@ -61,4 +62,38 @@
        NAMESPACE       : openebs
        NUMBER OF POOLS : 1
        TOTAL FREE      : 32 GiB
+      ```
+    * #### Describe `LocalPV-ZFS` PVCs
+      ```bash
+      $ kubectl openebs describe pvc csi-zfspv
+
+      csi-zfspv Details  :
+      -------------------
+      NAME               : csi-zfspv
+      NAMESPACE          : default
+      CAS TYPE           : localpv-zfs
+      BOUND VOLUME       : pvc-4aee0a2a-dccd-456b-95af-693ac8108be1
+      STORAGE CLASS      : openebs-zfspv
+      SIZE               : 4Gi
+      PVC STATUS         : Bound
+
+      pvc-4aee0a2a-dccd-456b-95af-693ac8108be1 Details :
+      ------------------
+      NAME              : pvc-4aee0a2a-dccd-456b-95af-693ac8108be1
+      NAMESPACE         : localpv-zfs
+      ACCESS MODE       : ReadWriteOnce
+      CSI DRIVER        : zfs.csi.openebs.io
+      CAPACITY          : 4Gi
+      PVC NAME          : csi-zfspv
+      VOLUME PHASE      : Bound
+      STORAGE CLASS     : openebs-zfspv
+      VERSION           : 1.9.1
+      ZFS VOLUME STATUS : Ready
+      VOLUME TYPE       : DATASET
+      POOL NAME         : zfspv-pool
+      FILE SYSTEM       : zfs
+      COMPRESSION       : off
+      DEDUPLICATION     : off
+      NODE ID           : node2-virtual-machine
+      RECORD SIZE       : 4k
       ```

--- a/pkg/cluster-info/cluster-info_test.go
+++ b/pkg/cluster-info/cluster-info_test.go
@@ -1,0 +1,1 @@
+package cluster_info

--- a/pkg/cluster-info/cluster-info_test.go
+++ b/pkg/cluster-info/cluster-info_test.go
@@ -1,1 +1,0 @@
-package cluster_info

--- a/pkg/persistentvolumeclaim/lvmlocalpv.go
+++ b/pkg/persistentvolumeclaim/lvmlocalpv.go
@@ -53,7 +53,7 @@ func DescribeLVMVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCla
 	// 2. If PV is present Describe the LVM Volume
 	if pv != nil {
 		_ = util.PrintByTemplate("lvmPvc", lvmPvcInfoTemplate, lvmPVCinfo)
-		volume.DescribeLVMLocalPVs(c, pv)
+		_ = volume.DescribeLVMLocalPVs(c, pv)
 	} else {
 		// Show only PVC details if volume is not found.
 		_ = util.PrintByTemplate("lvmPvc", lvmPvcInfoTemplate, lvmPVCinfo)

--- a/pkg/persistentvolumeclaim/lvmlocalpv.go
+++ b/pkg/persistentvolumeclaim/lvmlocalpv.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/openebs/openebsctl/pkg/volume"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	lvmPvcInfoTemplate = `
+{{.Name}} Details  :
+-------------------
+NAME               : {{.Name}}
+NAMESPACE          : {{.Namespace}}
+CAS TYPE           : {{.CasType}}
+BOUND VOLUME       : {{.BoundVolume}}
+STORAGE CLASS      : {{.StorageClassName}}
+SIZE               : {{.Size}}
+PVC STATUS         : {{.PVCStatus}}
+`
+)
+
+// DescribeLVMVolumeClaim describes a LVM storage engine PersistentVolumeClaim
+func DescribeLVMVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume) error {
+	// 1. Fill in the PVC information
+	lvmPVCinfo := util.LVMPVCInfo{
+		Name:             pvc.Name,
+		Namespace:        pvc.Namespace,
+		CasType:          util.LVMCasType,
+		BoundVolume:      pvc.Spec.VolumeName,
+		StorageClassName: *pvc.Spec.StorageClassName,
+		Size:             pvc.Spec.Resources.Requests.Storage().String(),
+		PVCStatus:        pvc.Status.Phase,
+	}
+
+	// 2. If PV is present Describe the LVM Volume
+	if pv != nil {
+		_ = util.PrintByTemplate("lvmPvc", lvmPvcInfoTemplate, lvmPVCinfo)
+		volume.DescribeLVMLocalPVs(c, pv)
+	} else {
+		// Show only PVC details if volume is not found.
+		_ = util.PrintByTemplate("lvmPvc", lvmPvcInfoTemplate, lvmPVCinfo)
+	}
+
+	return nil
+}

--- a/pkg/persistentvolumeclaim/lvmlocalpv_test.go
+++ b/pkg/persistentvolumeclaim/lvmlocalpv_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openebs/lvm-localpv/pkg/generated/clientset/internalclientset/fake"
+	fakelvm "github.com/openebs/lvm-localpv/pkg/generated/clientset/internalclientset/typed/lvm/v1alpha1/fake"
+	"github.com/openebs/openebsctl/pkg/client"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stest "k8s.io/client-go/testing"
+)
+
+func TestDescribeLVMVolumeClaim(t *testing.T) {
+	type args struct {
+		c       *client.K8sClient
+		pvc     *corev1.PersistentVolumeClaim
+		pv      *corev1.PersistentVolume
+		lvmfunc func(sClient *client.K8sClient)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"Test with all valid values",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", LVMCS: fake.NewSimpleClientset(&lvmVol1), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:  &lvmPV1,
+				pvc: &lvmPVC1,
+			},
+			false,
+		},
+		{
+			"Test with PV missing",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", LVMCS: fake.NewSimpleClientset(&lvmVol1), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:  nil,
+				pvc: &lvmPVC1,
+			},
+			false,
+		},
+		{
+			"Test with LVM Vol missing",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", LVMCS: fake.NewSimpleClientset(), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:      &lvmPV1,
+				pvc:     &lvmPVC1,
+				lvmfunc: lvmVolNotExists,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.lvmfunc != nil {
+				tt.args.lvmfunc(tt.args.c)
+			}
+			if err := DescribeLVMVolumeClaim(tt.args.c, tt.args.pvc, tt.args.pv); (err != nil) != tt.wantErr {
+				t.Errorf("DescribeLVMVolumeClaim() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// lvmVolNotExists makes fakelvmClientSet return error
+func lvmVolNotExists(c *client.K8sClient) {
+	// NOTE: Set the VERB & Resource correctly & make it work for single resources
+	c.LVMCS.LocalV1alpha1().(*fakelvm.FakeLocalV1alpha1).Fake.PrependReactor("*", "*", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("failed to list LVMVolumes")
+	})
+}

--- a/pkg/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/persistentvolumeclaim/persistentvolumeclaim.go
@@ -75,5 +75,7 @@ func CasDescribeMap() map[string]func(*client.K8sClient, *corev1.PersistentVolum
 	return map[string]func(*client.K8sClient, *corev1.PersistentVolumeClaim, *corev1.PersistentVolume) error{
 		util.JivaCasType:  DescribeJivaVolumeClaim,
 		util.CstorCasType: DescribeCstorVolumeClaim,
+		util.LVMCasType:   DescribeLVMVolumeClaim,
+		util.ZFSCasType:   DescribeZFSVolumeClaim,
 	}
 }

--- a/pkg/persistentvolumeclaim/testdata_test.go
+++ b/pkg/persistentvolumeclaim/testdata_test.go
@@ -19,14 +19,12 @@ package persistentvolumeclaim
 import (
 	"time"
 
-	lvm "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
-	zfs "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
-	appsv1 "k8s.io/api/apps/v1"
-
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
+	lvm "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 	"github.com/openebs/openebsctl/pkg/util"
+	zfs "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
 	corev1 "k8s.io/api/core/v1"
 	v12 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -866,20 +864,6 @@ var lvmPVC1 = corev1.PersistentVolumeClaim{
 	},
 }
 
-var localpvCSICtrlSTS = appsv1.StatefulSet{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "StatefulSet",
-		APIVersion: "apps/v1",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "fake-LVM-CSI",
-		Namespace: "lvm",
-		Labels: map[string]string{
-			"openebs.io/version":        "1.9.0",
-			"openebs.io/component-name": "openebs-lvm-controller"},
-	},
-}
-
 /****************
 * ZFS LOCAL PV
 ****************/
@@ -967,19 +951,5 @@ var zfsPVC1 = corev1.PersistentVolumeClaim{
 	},
 	Status: corev1.PersistentVolumeClaimStatus{
 		Phase: corev1.PersistentVolumeClaimPhase(corev1.VolumeBound),
-	},
-}
-
-var localpvzfsCSICtrlSTS = appsv1.StatefulSet{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       "StatefulSet",
-		APIVersion: "apps/v1",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "fake-ZFS-CSI",
-		Namespace: "zfslocalpv",
-		Labels: map[string]string{
-			"openebs.io/version":        "1.9.0",
-			"openebs.io/component-name": "openebs-zfs-controller"},
 	},
 }

--- a/pkg/persistentvolumeclaim/testdata_test.go
+++ b/pkg/persistentvolumeclaim/testdata_test.go
@@ -19,6 +19,10 @@ package persistentvolumeclaim
 import (
 	"time"
 
+	lvm "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
+	zfs "github.com/openebs/zfs-localpv/pkg/apis/openebs.io/zfs/v1"
+	appsv1 "k8s.io/api/apps/v1"
+
 	v1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
 	cstortypes "github.com/openebs/api/v2/pkg/apis/types"
@@ -31,6 +35,7 @@ import (
 
 var (
 	fourGigiByte = resource.MustParse("4Gi")
+	blockFS      = corev1.PersistentVolumeBlock
 )
 
 /****************
@@ -768,4 +773,213 @@ var cvrEvent2 = corev1.Event{
 	Count:   1,
 	Type:    "Warning",
 	Action:  "some-fake-action",
+}
+
+/****************
+* LVM LOCAL PV
+****************/
+
+var lvmScName = "lvmsc"
+
+var lvmVol1 = lvm.LVMVolume{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "LVMVolume",
+		APIVersion: "lvm.openebs.io/v1alpha1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:              "pvc-1",
+		Namespace:         "lvmlocalpv",
+		CreationTimestamp: metav1.Time{Time: time.Now()},
+		Labels:            map[string]string{},
+		Annotations:       map[string]string{},
+		OwnerReferences:   nil,
+		Finalizers:        nil,
+	},
+	Spec: lvm.VolumeInfo{
+		OwnerNodeID:   "node1",
+		VolGroup:      "lvmpv",
+		VgPattern:     "vg1*",
+		Capacity:      "4Gi",
+		Shared:        "NotShared",
+		ThinProvision: "No",
+	},
+	Status: lvm.VolStatus{
+		State: "Ready",
+		Error: nil,
+	},
+}
+
+var lvmPV1 = corev1.PersistentVolume{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "PersistentVolume",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "pvc-1",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	},
+	Spec: corev1.PersistentVolumeSpec{
+		// 4GiB
+		Capacity:               corev1.ResourceList{corev1.ResourceStorage: fourGigiByte},
+		PersistentVolumeSource: corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: util.LocalPVLVMCSIDriver}},
+		AccessModes:            []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		ClaimRef: &corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "pvc-namespace",
+			Name: "lvm-pvc-1", APIVersion: "v1"},
+		PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+		StorageClassName:              "lvm-sc-1",
+		VolumeMode:                    &blockFS,
+		NodeAffinity: &corev1.VolumeNodeAffinity{
+			Required: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{
+					{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node2"}},
+				}},
+			}},
+		},
+	},
+	Status: corev1.PersistentVolumeStatus{
+		Phase:   corev1.VolumeBound,
+		Message: "Storage class not found",
+		Reason:  "K8s API was down",
+	},
+}
+
+var lvmPVC1 = corev1.PersistentVolumeClaim{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "PersistentVolumeClaim",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "lvm-pvc",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	},
+	Spec: corev1.PersistentVolumeClaimSpec{
+		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		Resources:        corev1.ResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: fourGigiByte}},
+		VolumeName:       "pvc-1",
+		StorageClassName: &lvmScName,
+		VolumeMode:       &blockFS,
+	},
+	Status: corev1.PersistentVolumeClaimStatus{
+		Phase: corev1.PersistentVolumeClaimPhase(corev1.VolumeBound),
+	},
+}
+
+var localpvCSICtrlSTS = appsv1.StatefulSet{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "StatefulSet",
+		APIVersion: "apps/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "fake-LVM-CSI",
+		Namespace: "lvm",
+		Labels: map[string]string{
+			"openebs.io/version":        "1.9.0",
+			"openebs.io/component-name": "openebs-lvm-controller"},
+	},
+}
+
+/****************
+* ZFS LOCAL PV
+****************/
+
+var zfsVol1 = zfs.ZFSVolume{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "ZFSVolume",
+		APIVersion: "zfs.openebs.io/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:              "pvc-1",
+		Namespace:         "zfslocalpv",
+		CreationTimestamp: metav1.Time{Time: time.Now()},
+		Labels:            map[string]string{"kubernetes.io/nodename": "node1"},
+		Annotations:       map[string]string{},
+		OwnerReferences:   nil,
+		Finalizers:        nil,
+	},
+	Spec: zfs.VolumeInfo{
+		OwnerNodeID:   "node1",
+		PoolName:      "zfspv",
+		Capacity:      "4Gi",
+		RecordSize:    "4k",
+		Compression:   "off",
+		Dedup:         "off",
+		ThinProvision: "No",
+		VolumeType:    "DATASET",
+		FsType:        "zfs",
+		Shared:        "NotShared",
+	},
+	Status: zfs.VolStatus{State: "Ready"},
+}
+
+var zfsPV1 = corev1.PersistentVolume{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "PersistentVolume",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "pvc-1",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	},
+	Spec: corev1.PersistentVolumeSpec{
+		// 4GiB
+		Capacity:               corev1.ResourceList{corev1.ResourceStorage: fourGigiByte},
+		PersistentVolumeSource: corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: util.ZFSCSIDriver}},
+		AccessModes:            []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		ClaimRef: &corev1.ObjectReference{Kind: "PersistentVolumeClaim", Namespace: "pvc-namespace",
+			Name: "zfs-pvc-1", APIVersion: "v1"},
+		PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+		StorageClassName:              "zfs-sc-1",
+		VolumeMode:                    &blockFS,
+		NodeAffinity: &corev1.VolumeNodeAffinity{
+			Required: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{MatchExpressions: []corev1.NodeSelectorRequirement{
+					{Key: "kubernetes.io/hostname", Operator: corev1.NodeSelectorOpIn, Values: []string{"node2"}},
+				}},
+			}},
+		},
+	},
+	Status: corev1.PersistentVolumeStatus{
+		Phase:   corev1.VolumeBound,
+		Message: "Storage class not found",
+		Reason:  "K8s API was down",
+	},
+}
+
+var zfsPVC1 = corev1.PersistentVolumeClaim{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "PersistentVolumeClaim",
+		APIVersion: "core/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "zfs-pvc",
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	},
+	Spec: corev1.PersistentVolumeClaimSpec{
+		AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		Resources:        corev1.ResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: fourGigiByte}},
+		VolumeName:       "pvc-1",
+		StorageClassName: &lvmScName,
+		VolumeMode:       &blockFS,
+	},
+	Status: corev1.PersistentVolumeClaimStatus{
+		Phase: corev1.PersistentVolumeClaimPhase(corev1.VolumeBound),
+	},
+}
+
+var localpvzfsCSICtrlSTS = appsv1.StatefulSet{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "StatefulSet",
+		APIVersion: "apps/v1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "fake-ZFS-CSI",
+		Namespace: "zfslocalpv",
+		Labels: map[string]string{
+			"openebs.io/version":        "1.9.0",
+			"openebs.io/component-name": "openebs-zfs-controller"},
+	},
 }

--- a/pkg/persistentvolumeclaim/zfslocalpv.go
+++ b/pkg/persistentvolumeclaim/zfslocalpv.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/openebs/openebsctl/pkg/volume"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	zfsPvcInfoTemplate = `
+{{.Name}} Details  :
+-------------------
+NAME               : {{.Name}}
+NAMESPACE          : {{.Namespace}}
+CAS TYPE           : {{.CasType}}
+BOUND VOLUME       : {{.BoundVolume}}
+STORAGE CLASS      : {{.StorageClassName}}
+SIZE               : {{.Size}}
+PVC STATUS         : {{.PVCStatus}}
+`
+)
+
+// DescribeZFSVolumeClaim describes a ZFS storage engine PersistentVolumeClaim
+func DescribeZFSVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume) error {
+	zfsPVCinfo := util.ZFSPVCInfo{
+		Name:             pvc.Name,
+		Namespace:        pvc.Namespace,
+		CasType:          util.ZFSCasType,
+		BoundVolume:      pvc.Spec.VolumeName,
+		StorageClassName: *pvc.Spec.StorageClassName,
+		Size:             pvc.Spec.Resources.Requests.Storage().String(),
+		PVCStatus:        pvc.Status.Phase,
+	}
+
+	if pv != nil {
+		_ = util.PrintByTemplate("zfsPvc", zfsPvcInfoTemplate, zfsPVCinfo)
+		volume.DescribeZFSLocalPVs(c, pv)
+	} else {
+		_ = util.PrintByTemplate("ZFSPvc", zfsPvcInfoTemplate, zfsPVCinfo)
+	}
+
+	return nil
+}

--- a/pkg/persistentvolumeclaim/zfslocalpv.go
+++ b/pkg/persistentvolumeclaim/zfslocalpv.go
@@ -51,7 +51,7 @@ func DescribeZFSVolumeClaim(c *client.K8sClient, pvc *corev1.PersistentVolumeCla
 
 	if pv != nil {
 		_ = util.PrintByTemplate("zfsPvc", zfsPvcInfoTemplate, zfsPVCinfo)
-		volume.DescribeZFSLocalPVs(c, pv)
+		_ = volume.DescribeZFSLocalPVs(c, pv)
 	} else {
 		_ = util.PrintByTemplate("ZFSPvc", zfsPvcInfoTemplate, zfsPVCinfo)
 	}

--- a/pkg/persistentvolumeclaim/zfslocalpv_test.go
+++ b/pkg/persistentvolumeclaim/zfslocalpv_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package persistentvolumeclaim
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset/fake"
+	fakezfs "github.com/openebs/zfs-localpv/pkg/generated/clientset/internalclientset/typed/zfs/v1/fake"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stest "k8s.io/client-go/testing"
+)
+
+func TestDescribeZFSVolumeClaim(t *testing.T) {
+	type args struct {
+		c       *client.K8sClient
+		pvc     *corev1.PersistentVolumeClaim
+		pv      *corev1.PersistentVolume
+		zfsfunc func(sClient *client.K8sClient)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"Test with all valid values",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", ZFCS: fake.NewSimpleClientset(&zfsVol1), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:  &zfsPV1,
+				pvc: &zfsPVC1,
+			},
+			false,
+		},
+		{
+			"Test with PV missing",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", ZFCS: fake.NewSimpleClientset(&zfsVol1), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:  nil,
+				pvc: &zfsPVC1,
+			},
+			false,
+		},
+		{
+			"Test with ZFS Vol missing",
+			args{c: &client.K8sClient{Ns: "lvmlocalpv", ZFCS: fake.NewSimpleClientset(), K8sCS: k8sfake.NewSimpleClientset()},
+				pv:      &zfsPV1,
+				pvc:     &zfsPVC1,
+				zfsfunc: zfsVolNotExists,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.zfsfunc != nil {
+				tt.args.zfsfunc(tt.args.c)
+			}
+			if err := DescribeZFSVolumeClaim(tt.args.c, tt.args.pvc, tt.args.pv); (err != nil) != tt.wantErr {
+				t.Errorf("DescribeZFSVolumeClaim() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// zfsVolNotExists makes fakezfsClientSet return error
+func zfsVolNotExists(c *client.K8sClient) {
+	// NOTE: Set the VERB & Resource correctly & make it work for single resources
+	c.ZFCS.ZfsV1().(*fakezfs.FakeZfsV1).Fake.PrependReactor("*", "*", func(action k8stest.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("failed to list ZFSVolumes")
+	})
+}

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -143,6 +143,30 @@ type JivaPVCInfo struct {
 	PVStatus         corev1.PersistentVolumePhase
 }
 
+// LVMPVCInfo struct will have all the details we want to give in the output for describe pvc
+// details section for lvm pvc
+type LVMPVCInfo struct {
+	Name             string
+	Namespace        string
+	CasType          string
+	BoundVolume      string
+	StorageClassName string
+	Size             string
+	PVCStatus        corev1.PersistentVolumeClaimPhase
+}
+
+// ZFSPVCInfo struct will have all the details we want to give in the output for describe pvc
+// details section for zfs pvc
+type ZFSPVCInfo struct {
+	Name             string
+	Namespace        string
+	CasType          string
+	BoundVolume      string
+	StorageClassName string
+	Size             string
+	PVCStatus        corev1.PersistentVolumeClaimPhase
+}
+
 // PVCInfo struct will have all the details we want to give in the output for describe pvc
 // details section for non-cstor pvc
 type PVCInfo struct {
@@ -266,7 +290,7 @@ type LVMVolDesc struct {
 // ComponentData stores the data for each component of an engine
 type ComponentData struct {
 	Namespace string
-	Status string
-	Version string
-	CasType string
+	Status    string
+	Version   string
+	CasType   string
 }

--- a/pkg/volume/lvmlocalpv_test.go
+++ b/pkg/volume/lvmlocalpv_test.go
@@ -167,15 +167,9 @@ func TestDescribeLVMLocalPVs(t *testing.T) {
 			false,
 		},
 		{"one lvm volume present and asked for but namespace wrong",
-			args{c: &client.K8sClient{Ns: "lvmlocalpv", LVMCS: fake.NewSimpleClientset(&lvmVol1)},
+			args{c: &client.K8sClient{Ns: "lvmlocalpv1", LVMCS: fake.NewSimpleClientset(&lvmVol1), K8sCS: k8sfake.NewSimpleClientset()},
 				vol: &lvmPV1, lvmfunc: lvmVolNotExists},
-			true,
-		},
-		{"one lvm volume present and some other volume asked for",
-			args{c: &client.K8sClient{Ns: "lvm", K8sCS: k8sfake.NewSimpleClientset(&lvmPV1), LVMCS: fake.NewSimpleClientset(&lvmVol1)},
-				vol:     &cstorPV2,
-				lvmfunc: lvmVolNotExists},
-			true,
+			false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/volume/lvmlocalpv_test.go
+++ b/pkg/volume/lvmlocalpv_test.go
@@ -171,6 +171,13 @@ func TestDescribeLVMLocalPVs(t *testing.T) {
 				vol: &lvmPV1, lvmfunc: lvmVolNotExists},
 			false,
 		},
+		{
+			"one lvm volume present and some other volume asked for",
+			args{c: &client.K8sClient{Ns: "lvm", K8sCS: k8sfake.NewSimpleClientset(&lvmPV1), LVMCS: fake.NewSimpleClientset(&lvmVol1)},
+				vol:     &cstorPV2,
+				lvmfunc: lvmVolNotExists},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/volume/zfs_locapv.go
+++ b/pkg/volume/zfs_locapv.go
@@ -28,24 +28,24 @@ import (
 
 const zfsVolInfo = `
 {{.Name}} Details :
------------------
-Name          : {{.Name}}
-Namespace     : {{.Namespace}}
-AccessMode    : {{.AccessMode}}
-CSIDriver     : {{.CSIDriver}}
-Capacity      : {{.Capacity}}
-PVC           : {{.PVC}}
-VolumePhase   : {{.VolumePhase}}
-StorageClass  : {{.StorageClass}}
-Version       : {{.Version}}
-Status        : {{.Status}}
-VolumeType    : {{.VolumeType}}
-PoolName      : {{.PoolName}}
-FileSystem    : {{.FileSystem}}
-Compression   : {{.Compression}}
-Deduplication : {{.Dedup}}
-NodeID        : {{.NodeID}}
-Recordsize    : {{.Recordsize}}
+------------------
+NAME              : {{.Name}}
+NAMESPACE         : {{.Namespace}}
+ACCESS MODE       : {{.AccessMode}}
+CSI DRIVER        : {{.CSIDriver}}
+CAPACITY          : {{.Capacity}}
+PVC NAME          : {{.PVC}}
+VOLUME PHASE      : {{.VolumePhase}}
+STORAGE CLASS     : {{.StorageClass}}
+VERSION           : {{.Version}}
+ZFS VOLUME STATUS : {{.Status}}
+VOLUME TYPE       : {{.VolumeType}}
+POOL NAME         : {{.PoolName}}
+FILE SYSTEM       : {{.FileSystem}}
+COMPRESSION       : {{.Compression}}
+DEDUPLICATION     : {{.Dedup}}
+NODE ID           : {{.NodeID}}
+RECORD SIZE       : {{.Recordsize}}
 `
 
 // GetZFSLocalPVs returns a list of ZFSVolumes
@@ -103,42 +103,52 @@ func DescribeZFSLocalPVs(c *client.K8sClient, vol *corev1.PersistentVolume) erro
 	if vol == nil {
 		return fmt.Errorf("ZFS volume nil")
 	}
-	zvols, _, err := c.GetZFSVols([]string{vol.Name}, util.List, "", util.MapOptions{})
-	if err != nil {
-		return err
-	}
-	zvol := zvols.Items[0]
+	// 1. Fetch the version from the CSI Controller STS labels
 	var version string
 	if CSIctrl, err := c.GetCSIControllerSTS(util.ZFSLocalPVcsiControllerLabelValue); err == nil {
 		version = CSIctrl.Labels["openebs.io/version"]
 	}
+	// Assign N/A if not found
 	if version == "" {
 		version = "N/A"
 	}
-	// TODO: Can NDM mark a zfs-localpv used volume as Claimed
-	// 1. Show some ZFS-pools
+	// 2. Fill the details using the Persistent Volume
 	v := util.ZFSVolDesc{
 		AccessMode: util.AccessModeToString(vol.Spec.AccessModes),
 		Capacity:   vol.Spec.Capacity.Storage().String(),
 		CSIDriver:  vol.Spec.CSI.Driver,
 		Name:       vol.Name,
-		Namespace:  zvol.Namespace,
 		// assuming that zfsPVs aren't static-ally provisioned
 		PVC:          vol.Spec.ClaimRef.Name,
 		VolumePhase:  vol.Status.Phase,
 		StorageClass: vol.Spec.StorageClassName,
 		Version:      version,
-		// fix the duplicate entry
-		Status:      zvol.Status.State,
-		VolumeType:  zvol.Spec.VolumeType, // DATASET or ZVOL
-		PoolName:    zvol.Spec.PoolName,
-		FileSystem:  zvol.Spec.FsType,
-		Compression: zvol.Spec.Compression,
-		Dedup:       zvol.Spec.Dedup,
-		NodeID:      zvol.Spec.OwnerNodeID,
-		Recordsize:  zvol.Spec.RecordSize,
 	}
+	// 3. Fetch the corresponding ZFS Volume CR and fill in the other details
+	printErr := false
+	zvols, _, err := c.GetZFSVols([]string{vol.Name}, util.List, "", util.MapOptions{})
+	if err != nil {
+		printErr = true
+	} else {
+		zvol := zvols.Items[0]
+		v.Namespace = zvol.Namespace
+		v.Status = zvol.Status.State
+		v.VolumeType = zvol.Spec.VolumeType // DATASET or ZVOL
+		v.PoolName = zvol.Spec.PoolName
+		v.FileSystem = zvol.Spec.FsType
+		v.Compression = zvol.Spec.Compression
+		v.Dedup = zvol.Spec.Dedup
+		v.NodeID = zvol.Spec.OwnerNodeID
+		v.Recordsize = zvol.Spec.RecordSize
+	}
+	// 4. Print the data
 	_ = util.PrintByTemplate("volume", zfsVolInfo, v)
+	if printErr {
+		// 5. Print the error is any
+		fmt.Println()
+		fmt.Fprintf(os.Stderr, "The LVMVol for %s doesnot exist", vol.Name)
+		fmt.Println()
+	}
 	// TODO: Add ZFSbackup, ZFSrestores, ZFSsnapshot info if available
 	return nil
 }

--- a/pkg/volume/zfs_locapv_test.go
+++ b/pkg/volume/zfs_locapv_test.go
@@ -174,15 +174,9 @@ func TestDescribeZFSLocalPVs(t *testing.T) {
 			false,
 		},
 		{"one zfs volume present and asked for but namespace wrong",
-			args{c: &client.K8sClient{Ns: "zfslocalpv", ZFCS: fake.NewSimpleClientset(&zfsVol1)},
+			args{c: &client.K8sClient{Ns: "zfslocalpv1", ZFCS: fake.NewSimpleClientset(&zfsVol1), K8sCS: k8sfake.NewSimpleClientset()},
 				vol: &zfsPV1, zfsfunc: zfsVolNotExists},
-			true,
-		},
-		{"one zfs volume present and some other volume asked for",
-			args{c: &client.K8sClient{Ns: "zfs", K8sCS: k8sfake.NewSimpleClientset(&zfsPV1), ZFCS: fake.NewSimpleClientset(&zfsVol1)},
-				vol:     &cstorPV2,
-				zfsfunc: zfsVolNotExists},
-			true,
+			false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/volume/zfs_locapv_test.go
+++ b/pkg/volume/zfs_locapv_test.go
@@ -178,6 +178,12 @@ func TestDescribeZFSLocalPVs(t *testing.T) {
 				vol: &zfsPV1, zfsfunc: zfsVolNotExists},
 			false,
 		},
+		{"one zfs volume present and some other volume asked for",
+			args{c: &client.K8sClient{Ns: "zfs", K8sCS: k8sfake.NewSimpleClientset(&zfsPV1), ZFCS: fake.NewSimpleClientset(&zfsVol1)},
+				vol:     &cstorPV2,
+				zfsfunc: zfsVolNotExists},
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
- This PR adds support for describing the LVM and ZFS PVCs.
- This PR changes the ZFS and LVM vol describe to not fail incase a ZFS vol or LVM vol goes missing, but PV is present.
- This PR adds unit tests for the same.

### Usage and Output
```
kubectl openebs describe pvc csi-zfspv

csi-zfspv Details  :
-------------------
NAME               : csi-zfspv
NAMESPACE          : default
CAS TYPE           : localpv-zfs
BOUND VOLUME       : pvc-4aee0a2a-dccd-456b-95af-693ac8108be1
STORAGE CLASS      : openebs-zfspv
SIZE               : 4Gi
PVC STATUS         : Bound

pvc-4aee0a2a-dccd-456b-95af-693ac8108be1 Details :
------------------
NAME              : pvc-4aee0a2a-dccd-456b-95af-693ac8108be1
NAMESPACE         : localpv-zfs
ACCESS MODE       : ReadWriteOnce 
CSI DRIVER        : zfs.csi.openebs.io
CAPACITY          : 4Gi
PVC NAME          : csi-zfspv
VOLUME PHASE      : Bound
STORAGE CLASS     : openebs-zfspv
VERSION           : 1.9.1
ZFS VOLUME STATUS : Ready
VOLUME TYPE       : DATASET
POOL NAME         : zfspv-pool
FILE SYSTEM       : zfs
COMPRESSION       : off
DEDUPLICATION     : off
NODE ID           : node2-virtual-machine
RECORD SIZE       : 4k

``` 

```
kubectl openebs describe pvc csi-lvmpv

csi-lvmpv Details  :
-------------------
NAME               : csi-lvmpv
NAMESPACE          : default
CAS TYPE           : localpv-lvm
BOUND VOLUME       : pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8
STORAGE CLASS      : openebs-lvmpv
SIZE               : 4Gi
PVC STATUS         : Bound

pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8 Details :
------------------
NAME              : pvc-109f0d33-cc41-4a3c-874d-f03d4c3073d8
NAMESPACE         : localpv-lvm
ACCESS MODE       : ReadWriteOnce 
CSI DRIVER        : local.csi.openebs.io
CAPACITY          : 4Gi
PVC NAME          : csi-lvmpv
VOLUME PHASE      : Bound
STORAGE CLASS     : openebs-lvmpv
VERSION           : 0.8.0
LVM VOLUME STATUS : Ready
VOLUME GROUP      : lvmvg
SHARED            : no
THIN PROVISIONED  : no
NODE ID           : node1-virtual-machine 
```

Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>