### PR TITLE
usability: Handle Exceptions for no resources

### DIFF
--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -89,9 +89,8 @@ func createTreeByNode(k *client.K8sClient, bdNames []string) error {
 	}
 	if len(rows) == 0 {
 		return util.HandleEmptyTableError("Block Device", k.Ns, "")
-	} else {
-		// Show the output using cli-runtime
-		util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	}
+	// Show the output using cli-runtime
+	util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -88,7 +88,7 @@ func createTreeByNode(k *client.K8sClient, bdNames []string) error {
 		rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", "", "", "", "", ""}})
 	}
 	if len(rows) == 0 {
-		util.HandleEmptyTableError("Block Device", k.Ns, "")
+		return util.HandleEmptyTableError("Block Device", k.Ns, "")
 	} else {
 		// Show the output using cli-runtime
 		util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -87,7 +87,11 @@ func createTreeByNode(k *client.K8sClient, bdNames []string) error {
 		// Add an empty row so that the tree looks neat
 		rows = append(rows, metav1.TableRow{Cells: []interface{}{"", "", "", "", "", "", ""}})
 	}
-	// Show the output using cli-runtime
-	util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
+	if len(rows) == 0 {
+		util.HandleEmptyTableError("Block Device", k.Ns, "")
+	} else {
+		// Show the output using cli-runtime
+		util.TablePrinter(util.BDTreeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
+	}
 	return nil
 }

--- a/pkg/storage/lvmlocalpv.go
+++ b/pkg/storage/lvmlocalpv.go
@@ -55,8 +55,7 @@ func GetVolumeGroups(c *client.K8sClient, vgs []string) ([]metav1.TableColumnDef
 	}
 	// 3. Actually print the table or return an error
 	if len(rows) == 0 {
-		// TODO: Improve this in issue #56
-		return nil, nil, fmt.Errorf("no lvm volumegroups found")
+		return nil, nil, util.HandleEmptyTableError("lvm Volumegroups", c.Ns, "")
 	}
 	return util.LVMvolgroupListColumnDefinitions, rows, nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -36,19 +36,31 @@ func Get(pools []string, openebsNS string, casType string) error {
 		if err != nil {
 			return err
 		}
-		util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
+		if len(rows) == 0 {
+			return util.HandleEmptyTableError("Storage", openebsNS, casType)
+		} else {
+			util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
+		}
 	} else if casType != "" {
 		return fmt.Errorf("cas-type %s is not supported", casType)
 	} else {
+		storageResourcesFound := false
 		// 3. Call all functions & exit
 		for _, f := range CasList() {
 			header, row, err := f(k, pools)
 			if err == nil {
+				if len(row) > 0 {
+					storageResourcesFound = true
+				}
 				// 4. Find the correct heading & print the rows
 				util.TablePrinter(header, row, printers.PrintOptions{Wide: true})
 				// A visual separator for different cas-type pools/storage entities
 				fmt.Println()
 			}
+		}
+
+		if !storageResourcesFound {
+			return util.HandleEmptyTableError("Storage", openebsNS, casType)
 		}
 	}
 	return nil

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -38,9 +38,8 @@ func Get(pools []string, openebsNS string, casType string) error {
 		}
 		if len(rows) == 0 {
 			return util.HandleEmptyTableError("Storage", openebsNS, casType)
-		} else {
-			util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
 		}
+		util.TablePrinter(header, rows, printers.PrintOptions{Wide: true})
 	} else if casType != "" {
 		return fmt.Errorf("cas-type %s is not supported", casType)
 	} else {

--- a/pkg/storage/zfslocalpv.go
+++ b/pkg/storage/zfslocalpv.go
@@ -57,7 +57,7 @@ func GetZFSPools(c *client.K8sClient, zfsnodes []string) ([]metav1.TableColumnDe
 	}
 	// 3. Actually print the table or return an error
 	if len(rows) == 0 {
-		return nil, nil, fmt.Errorf("no zfspools found")
+		return nil, nil, util.HandleEmptyTableError("zfs pools", c.Ns, "")
 	}
 	return util.ZFSPoolListColumnDefinitions, rows, nil
 }

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -40,3 +40,16 @@ func CheckErr(err error, handleErr func(string)) {
 	}
 	handleErr(err.Error())
 }
+
+// Handle Empty Table Error
+func HandleEmptyTableError(resource string, ns string, casType string) error {
+	if ns == "" && casType == "" {
+		return fmt.Errorf("no %s found in your cluster", resource)
+	} else if ns != "" && casType != "" {
+		return fmt.Errorf("no %s %s found in %s namespace", casType, resource, ns)
+	} else if casType != "" {
+		return fmt.Errorf("unknown cas-type %s", casType)
+	} else {
+		return fmt.Errorf("no %s found in %s namespace", resource, ns)
+	}
+}

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -41,7 +41,7 @@ func CheckErr(err error, handleErr func(string)) {
 	handleErr(err.Error())
 }
 
-// Handle Empty handles error when resources or set of resources are not found
+// HandleEmptyTableError handles error when resources or set of resources are not found
 func HandleEmptyTableError(resource string, ns string, casType string) error {
 	if ns == "" && casType == "" {
 		return fmt.Errorf("no %s found in your cluster", resource)

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -41,14 +41,14 @@ func CheckErr(err error, handleErr func(string)) {
 	handleErr(err.Error())
 }
 
-// Handle Empty Table Error
+// Handle Empty handles error when resources or set of resources are not found
 func HandleEmptyTableError(resource string, ns string, casType string) error {
 	if ns == "" && casType == "" {
 		return fmt.Errorf("no %s found in your cluster", resource)
 	} else if ns != "" && casType != "" {
 		return fmt.Errorf("no %s %s found in %s namespace", casType, resource, ns)
-	} else if casType != "" {
-		return fmt.Errorf("unknown cas-type %s", casType)
+	} else if casType != "" && !IsValidCasType(casType) {
+		return fmt.Errorf("cas-type %s not supported", casType)
 	} else {
 		return fmt.Errorf("no %s found in %s namespace", resource, ns)
 	}

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -65,8 +65,9 @@ func TestHandleEmptyTableError(t *testing.T) {
 		casType  string
 	}
 	tests := []struct {
-		name string
-		args args
+		name     string
+		args     args
+		expected error
 	}{
 		{
 			"No Namespace and cas",
@@ -75,14 +76,25 @@ func TestHandleEmptyTableError(t *testing.T) {
 				ns:       "",
 				casType:  "",
 			},
+			fmt.Errorf("no ResourceType found in your cluster"),
 		},
 		{
 			"Wrong cas or Namespace",
 			args{
 				resource: "ResourceType",
-				ns:       "InValidNamespace",
+				ns:       "InValid",
 				casType:  "jiva",
 			},
+			fmt.Errorf("no jiva ResourceType found in InValid namespace"),
+		},
+		{
+			"",
+			args{
+				resource: "ResourceType",
+				ns:       "invalid",
+				casType:  "",
+			},
+			fmt.Errorf("no ResourceType found in invalid namespace"),
 		},
 		{
 			"Wrong cas type in all namespace",
@@ -91,19 +103,23 @@ func TestHandleEmptyTableError(t *testing.T) {
 				ns:       "",
 				casType:  "invalid",
 			},
+			fmt.Errorf("cas-type invalid not supported"),
 		},
 		{
 			"Wrong Namespace and all cas types",
 			args{
 				resource: "ResourceType",
-				ns:       "InValidNamespace",
+				ns:       "InValid",
 				casType:  "",
 			},
+			fmt.Errorf("no ResourceType found in InValid namespace"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_ = HandleEmptyTableError(tt.args.resource, tt.args.ns, tt.args.casType)
+			if tResult := HandleEmptyTableError(tt.args.resource, tt.args.ns, tt.args.casType); tResult.Error() != tt.expected.Error() {
+				t.Errorf("HandleEmptyTableError(): expected: %s, got: %s", tt.expected, tResult)
+			}
 		})
 	}
 }

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -57,3 +57,53 @@ func TestCheckErr(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleEmptyTableError(t *testing.T) {
+	type args struct {
+		resource string
+		ns       string
+		casType  string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			"No Namespace and cas",
+			args{
+				resource: "ResourceType",
+				ns:       "",
+				casType:  "",
+			},
+		},
+		{
+			"Wrong cas or Namespace",
+			args{
+				resource: "ResourceType",
+				ns:       "InValidNamespace",
+				casType:  "jiva",
+			},
+		},
+		{
+			"Wrong cas type in all namespace",
+			args{
+				resource: "ResourceType",
+				ns:       "",
+				casType:  "invalid",
+			},
+		},
+		{
+			"Wrong Namespace and all cas types",
+			args{
+				resource: "ResourceType",
+				ns:       "InValidNamespace",
+				casType:  "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			HandleEmptyTableError(tt.args.resource, tt.args.ns, tt.args.casType)
+		})
+	}
+}

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -103,7 +103,7 @@ func TestHandleEmptyTableError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			HandleEmptyTableError(tt.args.resource, tt.args.ns, tt.args.casType)
+			_ = HandleEmptyTableError(tt.args.resource, tt.args.ns, tt.args.casType)
 		})
 	}
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -62,8 +62,13 @@ func Get(vols []string, openebsNS, casType string) error {
 			}
 		}
 	}
-	// 3. Print the volumes from rows
-	util.TablePrinter(util.VolumeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
+
+	if len(rows) == 0 {
+		return util.HandleEmptyTableError("Volume", openebsNS, casType)
+	} else {
+		// 3. Print the volumes from rows
+		util.TablePrinter(util.VolumeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
+	}
 	return nil
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -63,12 +63,11 @@ func Get(vols []string, openebsNS, casType string) error {
 		}
 	}
 
+	// 3. Return Error or Print volumes from rows
 	if len(rows) == 0 {
 		return util.HandleEmptyTableError("Volume", openebsNS, casType)
-	} else {
-		// 3. Print the volumes from rows
-		util.TablePrinter(util.VolumeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	}
+	util.TablePrinter(util.VolumeListColumnDefinations, rows, printers.PrintOptions{Wide: true})
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Abhishek-kumar09 <abhimait1909@gmail.com>

Fixes #56 

Now empty resource lists are handled by the openebsctl for storage, volumes and bd. They are handled separately on the basis of resourceType, casType and Namespaces.

![Screenshot from 2021-09-05 22-10-34](https://user-images.githubusercontent.com/48255244/132134587-6f36cb92-97ed-4fe8-aeb5-40348a4fb1ff.png)


