### PR TITLE
golangci-lint is not working in vscode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,3 +18,16 @@ linters-settings:
       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
       See the License for the specific language governing permissions and
       limitations under the License.
+
+enable:
+    - bodyclose
+    - deadcode
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - misspell
+  


### PR DESCRIPTION
Tried to check If this enable is working fine or not but It's not working .
![Screenshot (8)](https://user-images.githubusercontent.com/87513055/132369864-4b080911-9e85-4de0-9f5a-bcede1359327.png)
