### PR TITLE
Update cas-type name from local-hostpath to localpv-hostpath

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,4 +30,3 @@ enable:
     - goimports
     - golint
     - misspell
-  

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -106,7 +106,7 @@ var (
 		JivaCasType:           JivaCSIControllerLabelValue,
 		LVMCasType:            LVMLocalPVcsiControllerLabelValue,
 		ZFSCasType:            ZFSLocalPVcsiControllerLabelValue,
-		LocalHostpathCasLabel: HostpathComponentNames,
+		LocalPvHostpathCasType: HostpathComponentNames,
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
@@ -115,7 +115,7 @@ var (
 		JivaCSIControllerLabelValue:       JivaCasType,
 		LVMLocalPVcsiControllerLabelValue: LVMCasType,
 		ZFSLocalPVcsiControllerLabelValue: ZFSCasType,
-		HostpathComponentNames:            LocalHostpathCasLabel,
+		HostpathComponentNames:            LocalPvHostpathCasType,
 	}
 	// ProvsionerAndCasTypeMap stores the cas type name of the corresponding provisioner
 	ProvsionerAndCasTypeMap = map[string]string{

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -37,8 +37,8 @@ const (
 	LocalPvHostpathCasType = "localpv-hostpath"
 	// LocalDeviceCasType cas type name
 	LocalDeviceCasType = "localpv-device"
-	// Local-hostpath cas type name
-	LocalHostpathCasType = "local-hostpath"
+	// LocalHostpathCasLabel cas-type label in dynamic-localpv-provisioner
+	LocalHostpathCasLabel = "local-hostpath"
 	// Healthy cstor volume status
 	Healthy = "Healthy"
 	// StorageKey key present in pvc status.capacity
@@ -102,11 +102,11 @@ var (
 	// CasTypeAndComponentNameMap stores the component name of the corresponding cas type
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
 	CasTypeAndComponentNameMap = map[string]string{
-		CstorCasType:         CStorCSIControllerLabelValue,
-		JivaCasType:          JivaCSIControllerLabelValue,
-		LVMCasType:           LVMLocalPVcsiControllerLabelValue,
-		ZFSCasType:           ZFSLocalPVcsiControllerLabelValue,
-		LocalHostpathCasType: HostpathComponentNames,
+		CstorCasType:          CStorCSIControllerLabelValue,
+		JivaCasType:           JivaCSIControllerLabelValue,
+		LVMCasType:            LVMLocalPVcsiControllerLabelValue,
+		ZFSCasType:            ZFSLocalPVcsiControllerLabelValue,
+		LocalHostpathCasLabel: HostpathComponentNames,
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
@@ -115,7 +115,7 @@ var (
 		JivaCSIControllerLabelValue:       JivaCasType,
 		LVMLocalPVcsiControllerLabelValue: LVMCasType,
 		ZFSLocalPVcsiControllerLabelValue: ZFSCasType,
-		HostpathComponentNames:            LocalHostpathCasType,
+		HostpathComponentNames:            LocalHostpathCasLabel,
 	}
 	// ProvsionerAndCasTypeMap stores the cas type name of the corresponding provisioner
 	ProvsionerAndCasTypeMap = map[string]string{

--- a/pkg/volume/local_hostpath.go
+++ b/pkg/volume/local_hostpath.go
@@ -54,12 +54,14 @@ func GetLocalHostpath(c *client.K8sClient, pvList *corev1.PersistentVolumeList, 
 		capacity := pv.Spec.Capacity.Storage()
 		sc := pv.Spec.StorageClassName
 		attached := pv.Status.Phase
-		attachedNode, customStatus := pv.Labels["nodeID"], ""
-		var storageVersion, ns string
+		attachedNode := pv.Spec.NodeAffinity.Required.NodeSelectorTerms[0].MatchExpressions[0].Values[0]
+		var storageVersion, ns, customStatus string
 		deploy, err := c.GetDeploymentList("openebs.io/component-name=openebs-localpv-provisioner")
 		if err == nil && len(deploy.Items) == 1 {
 			storageVersion = deploy.Items[0].Labels["openebs.io/version"]
 			ns = deploy.Items[0].Namespace
+		} else {
+			storageVersion = "N/A"
 		}
 
 		accessMode := pv.Spec.AccessModes[0]

--- a/pkg/volume/local_hostpath.go
+++ b/pkg/volume/local_hostpath.go
@@ -40,24 +40,26 @@ RECLAIM POLICY  : {{.ReclaimPolicy}}
 `
 )
 
-// GetLocalHostpath returns a list of local-hostpath columes
+// GetLocalHostpath returns a list of localpv-hostpath columes
 func GetLocalHostpath(c *client.K8sClient, pvList *corev1.PersistentVolumeList, openebsNS string) ([]metav1.TableRow, error) {
 	var rows []metav1.TableRow
 	for _, pv := range pvList.Items {
 		// Ignore all the other volumes that is not of cas-type local-hostpath
-		if util.GetCasTypeFromPV(&pv) != util.LocalHostpathCasType {
+		// dynamic-local-provisioner has this label for PVs openebs.io/cas-type=local-hostpath
+		// this might be fixed later
+		if util.GetCasTypeFromPV(&pv) != util.LocalHostpathCasLabel {
 			continue
 		}
-
 		name := pv.Name
 		capacity := pv.Spec.Capacity.Storage()
 		sc := pv.Spec.StorageClassName
 		attached := pv.Status.Phase
-		attachedNode, customStatus, ns, storageVersion := pv.Labels["nodeID"], "N/A", "N/A", "N/A"
-
-		deployment, err := c.GetDeploymentList("openebs.io/component-name=openebs-localpv-provisioner")
-		if err == nil {
-			storageVersion = deployment.Items[0].Labels["openebs.io/version"]
+		attachedNode, customStatus := pv.Labels["nodeID"], ""
+		var storageVersion, ns string
+		deploy, err := c.GetDeploymentList("openebs.io/component-name=openebs-localpv-provisioner")
+		if err == nil && len(deploy.Items) == 1 {
+			storageVersion = deploy.Items[0].Labels["openebs.io/version"]
+			ns = deploy.Items[0].Namespace
 		}
 
 		accessMode := pv.Spec.AccessModes[0]
@@ -70,8 +72,8 @@ func GetLocalHostpath(c *client.K8sClient, pvList *corev1.PersistentVolumeList, 
 	return rows, nil
 }
 
-// DescribeLocalHostpathVolume describes a local-hostpath PersistentVolume
-func DescribeLocalHostpathVolume(c *client.K8sClient, vol *corev1.PersistentVolume) error {
+// DescribeLocalHostpathVolume describes a localpv-hostpath PersistentVolume
+func DescribeLocalHostpathVolume(_ *client.K8sClient, vol *corev1.PersistentVolume) error {
 	// Get Local-volume Information
 	localHostpathVolInfo := util.LocalHostPathVolInfo{
 		VolumeInfo: util.VolumeInfo{
@@ -85,7 +87,7 @@ func DescribeLocalHostpathVolume(c *client.K8sClient, vol *corev1.PersistentVolu
 		},
 		Path:          vol.Spec.PersistentVolumeSource.Local.Path,
 		ReclaimPolicy: string(vol.Spec.PersistentVolumeReclaimPolicy),
-		CasType:       util.LocalHostpathCasType,
+		CasType:       util.LocalPvHostpathCasType,
 	}
 
 	// Print the Volume information

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -129,11 +129,11 @@ func CasList() []func(*client.K8sClient, *corev1.PersistentVolumeList, string) (
 func CasListMap() map[string]func(*client.K8sClient, *corev1.PersistentVolumeList, string) ([]metav1.TableRow, error) {
 	// a good hack to implement immutable maps in Golang & also write tests for it
 	return map[string]func(*client.K8sClient, *corev1.PersistentVolumeList, string) ([]metav1.TableRow, error){
-		util.JivaCasType:          GetJiva,
-		util.CstorCasType:         GetCStor,
-		util.ZFSCasType:           GetZFSLocalPVs,
-		util.LVMCasType:           GetLVMLocalPV,
-		util.LocalHostpathCasType: GetLocalHostpath,
+		util.JivaCasType:            GetJiva,
+		util.CstorCasType:           GetCStor,
+		util.ZFSCasType:             GetZFSLocalPVs,
+		util.LVMCasType:             GetLVMLocalPV,
+		util.LocalPvHostpathCasType: GetLocalHostpath,
 	}
 }
 
@@ -141,10 +141,10 @@ func CasListMap() map[string]func(*client.K8sClient, *corev1.PersistentVolumeLis
 func CasDescribeMap() map[string]func(*client.K8sClient, *corev1.PersistentVolume) error {
 	// a good hack to implement immutable maps in Golang & also write tests for it
 	return map[string]func(*client.K8sClient, *corev1.PersistentVolume) error{
-		util.JivaCasType:          DescribeJivaVolume,
-		util.CstorCasType:         DescribeCstorVolume,
-		util.ZFSCasType:           DescribeZFSLocalPVs,
-		util.LVMCasType:           DescribeLVMLocalPVs,
-		util.LocalHostpathCasType: DescribeLocalHostpathVolume,
+		util.JivaCasType:            DescribeJivaVolume,
+		util.CstorCasType:           DescribeCstorVolume,
+		util.ZFSCasType:             DescribeZFSLocalPVs,
+		util.LVMCasType:             DescribeLVMLocalPVs,
+		util.LocalPvHostpathCasType: DescribeLocalHostpathVolume,
 	}
 }


### PR DESCRIPTION
Summary: dynamic-localpv-provisioner currently sets the label key for
PVs as `openebs.io/cas-type=local-hostpath`

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>