### PR TITLE
usability: Get kubeconfig file from CLI Args

### DIFF
--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -18,11 +18,12 @@ package cmd
 
 import (
 	"flag"
+
 	cluster_info "github.com/openebs/openebsctl/cmd/cluster-info"
+	"github.com/openebs/openebsctl/pkg/util"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/openebs/openebsctl/cmd/completion"
 	"github.com/openebs/openebsctl/cmd/describe"
@@ -50,6 +51,7 @@ Flags:
       --cas-type                       to specify the cas-type of the engine, for engine based filtering.
                                        ex- cstor, jiva, localpv-lvm, localpv-zfs.
       --debug                          to launch the debugging mode for cstor pvcs.
+  -c, --kubeconfig                     Path to configuration file
 
 Use "kubectl openebs command --help" for more information about a command.
 `
@@ -71,11 +73,8 @@ Find out more about OpenEBS on https://openebs.io/`,
 		TraverseChildren: true,
 	}
 	cmd.SetUsageTemplate(usageTemplate)
-	// TODO: Check if this brings in the flags from kubectl binary to this one via exec for all platforms
-	kubernetesConfigFlags := genericclioptions.NewConfigFlags(true)
-	kubernetesConfigFlags.AddFlags(cmd.PersistentFlags())
 	cmd.AddCommand(
-		// Add a helper command to show what version of X is installed
+		// Add a helper command to show what version of X is installedCfgFile
 		completion.NewCmdCompletion(cmd),
 		get.NewCmdGet(cmd),
 		describe.NewCmdDescribe(cmd),
@@ -83,6 +82,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 		cluster_info.NewCmdClusterInfo(cmd),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
+	cmd.PersistentFlags().StringVarP(&util.Kubeconfig, "kubeconfig", "c", "", "path to config file")
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	_ = flag.CommandLine.Parse([]string{})
 	_ = viper.BindPFlag("namespace", cmd.PersistentFlags().Lookup("namespace"))

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -74,7 +74,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 	}
 	cmd.SetUsageTemplate(usageTemplate)
 	cmd.AddCommand(
-		// Add a helper command to show what version of X is installedCfgFile
+		// Add a helper command to show what version of X is installed
 		completion.NewCmdCompletion(cmd),
 		get.NewCmdGet(cmd),
 		describe.NewCmdDescribe(cmd),

--- a/go.sum
+++ b/go.sum
@@ -121,7 +121,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -184,7 +183,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -217,7 +215,6 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -352,7 +349,6 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -790,7 +786,6 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyz
 sigs.k8s.io/controller-runtime v0.2.0/go.mod h1:ZHqrRDZi3f6BzONcvlUxkqCKgwasGk5FZrnSv9TVZF4=
 sigs.k8s.io/controller-runtime v0.8.2 h1:SBWmI0b3uzMIUD/BIXWNegrCeZmPJ503pOtwxY0LPHM=
 sigs.k8s.io/controller-runtime v0.8.2/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
-sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -18,8 +18,8 @@ package client
 
 import (
 	"context"
-	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,15 +103,21 @@ func NewK8sClient(ns string) (*K8sClient, error) {
 // sets the env variable for the same
 func GetOutofClusterKubeConfig() {
 	var kubeconfig *string
-	if home := homeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.
-			Join(home, ".kube", "config"), "absolute path to kubeconfig")
+	// config file not provided, auto detect from the host OS
+	if util.Kubeconfig == "" {
+		if home := homeDir(); home != "" {
+			cfg := filepath.Join(home, ".kube", "config")
+			kubeconfig = &cfg
+		} else {
+			log.Fatal(`kubeconfig not provided, Please provide config file path with "--kubeconfig" flag`)
+		}
 	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig")
+		// Get the kubeconfig file from CLI args
+		kubeconfig = &util.Kubeconfig
 	}
-	flag.Parse()
 	err := os.Setenv("KUBECONFIG", *kubeconfig)
 	if err != nil {
+		log.Fatal(err)
 		return
 	}
 }

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -102,10 +102,10 @@ var (
 	// CasTypeAndComponentNameMap stores the component name of the corresponding cas type
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
 	CasTypeAndComponentNameMap = map[string]string{
-		CstorCasType:          CStorCSIControllerLabelValue,
-		JivaCasType:           JivaCSIControllerLabelValue,
-		LVMCasType:            LVMLocalPVcsiControllerLabelValue,
-		ZFSCasType:            ZFSLocalPVcsiControllerLabelValue,
+		CstorCasType:           CStorCSIControllerLabelValue,
+		JivaCasType:            JivaCSIControllerLabelValue,
+		LVMCasType:             LVMLocalPVcsiControllerLabelValue,
+		ZFSCasType:             ZFSLocalPVcsiControllerLabelValue,
 		LocalPvHostpathCasType: HostpathComponentNames,
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/klog"
 )
 
+var Kubeconfig string
+
 const (
 	maxTerms                = 2
 	stringsToBeColoredGreen = "healthy bound online active claimed running attached normal"


### PR DESCRIPTION
Fix #117 
support for Getting kubeconfig file from cli flags
```console
$ kubectl openebs version --kubeconfig ~/newlocation/config 


COMPONENT             VERSION
Client                dev
OpenEBS CStor         Not Installed
OpenEBS Jiva          2.12.2
OpenEBS LVM LocalPV   Not Installed
OpenEBS ZFS LocalPV   Not Installed

You are using development version of cli, latest released version is: v0.4.0
```
Signed-off-by: Abhishek-kumar09 <abhimait1909@gmail.com>