### PR TITLE
refractor: Wrap NewK8sClient for error handling in client init

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -53,7 +53,7 @@ func NewCmdVersion(rootCmd *cobra.Command) *cobra.Command {
 		Use:   "version",
 		Short: "Shows openebs kubectl plugin's version",
 		Run: func(cmd *cobra.Command, args []string) {
-			k, _ := client.NewK8sClient("")
+			k := client.NewK8sClient()
 			componentVersionMap, err := k.GetVersionMapOfComponents()
 
 			if err != nil {

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -34,7 +34,7 @@ const (
 // Get manages various implementations of blockdevice listing
 func Get(bds []string, openebsNS string) error {
 	// TODO: Prefer passing the client from outside
-	k, _ := client.NewK8sClient(openebsNS)
+	k := client.NewK8sClient(openebsNS)
 	err := createTreeByNode(k, bds)
 	if err != nil {
 		return err

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,10 +73,33 @@ type K8sClient struct {
 	CLIENT CREATION METHODS AND RELATED OPERATIONS
 */
 
-// NewK8sClient creates a new K8sClient
+// A wrapper around newK8sClient to handle errors in creating
+// clients implicitilty and simulating namespace as an optional
+// param for better code usability
+// ns: kubernetes namespace
+func NewK8sClient(ns ...string) *K8sClient {
+	// If more than one-namespace is provided as a function param, throw error and exit
+	if len(ns) > 1 {
+		log.Fatal("Only one namespace arg is allowed")
+	}
+
+	namespace := ""
+	if len(ns) == 1 {
+		namespace = ns[0]
+	}
+
+	k, err := newK8sClient(namespace)
+	if err != nil {
+		log.Fatal("error creating kubernetes client: ", err)
+	}
+
+	return k
+}
+
+// newK8sClient creates a new K8sClient
 // TODO: improve K8sClientset instantiation. for example remove the Ns from
 // K8sClient struct
-func NewK8sClient(ns string) (*K8sClient, error) {
+func newK8sClient(ns string) (*K8sClient, error) {
 	// get the appropriate clientsets & set the kubeconfig accordingly
 	// TODO: The kubeconfig should ideally be initialized in the CLI depending on various flags
 	GetOutofClusterKubeConfig()

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -73,9 +73,9 @@ type K8sClient struct {
 	CLIENT CREATION METHODS AND RELATED OPERATIONS
 */
 
-// A wrapper around newK8sClient to handle errors in creating
-// clients implicitilty and simulating namespace as an optional
-// param for better code usability
+// NewK8sClient is a wrapper around newK8sClient to handle errors in
+// creating clients implicitilty and simulating namespace as an optional
+// parameter for better code usability
 // ns: kubernetes namespace
 func NewK8sClient(ns ...string) *K8sClient {
 	// If more than one-namespace is provided as a function param, throw error and exit

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -74,8 +74,7 @@ type K8sClient struct {
 */
 
 // NewK8sClient is a wrapper around newK8sClient to handle errors in
-// creating clients implicitilty and simulating namespace as an optional
-// parameter for better code usability
+// creating clients implicitilty and simulating namespace as an optional parameter
 // ns: kubernetes namespace
 func NewK8sClient(ns ...string) *K8sClient {
 	// If more than one-namespace is provided as a function param, throw error and exit

--- a/pkg/cluster-info/cluster-info.go
+++ b/pkg/cluster-info/cluster-info.go
@@ -29,7 +29,7 @@ import (
 
 // ShowClusterInfo shows the openebs components and their status and versions
 func ShowClusterInfo() error {
-	k, _ := client.NewK8sClient("")
+	k := client.NewK8sClient()
 	err := compute(k)
 	return err
 }

--- a/pkg/persistentvolumeclaim/debug.go
+++ b/pkg/persistentvolumeclaim/debug.go
@@ -31,7 +31,7 @@ func Debug(pvcs []string, namespace string, openebsNs string) error {
 		return errors.New("please provide atleast one pvc name to describe")
 	}
 	// Clienset creation
-	k, _ := client.NewK8sClient(openebsNs)
+	k := client.NewK8sClient(openebsNs)
 
 	// 1. Get a list of required PersistentVolumeClaims
 	var pvcList *corev1.PersistentVolumeClaimList

--- a/pkg/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/pkg/persistentvolumeclaim/persistentvolumeclaim.go
@@ -29,7 +29,7 @@ func Describe(pvcs []string, namespace string, openebsNs string) error {
 		return errors.New("please provide atleast one pvc name to describe")
 	}
 	// Clienset creation
-	k, _ := client.NewK8sClient(openebsNs)
+	k := client.NewK8sClient(openebsNs)
 
 	// 1. Get a list of required PersistentVolumeClaims
 	var pvcList *corev1.PersistentVolumeClaimList

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -29,7 +29,7 @@ import (
 // Get manages various implementations of Storage listing
 func Get(pools []string, openebsNS string, casType string) error {
 	// 1. Create the clientset
-	k, _ := client.NewK8sClient("")
+	k := client.NewK8sClient()
 	// 2. If casType is specified, call the specific function & exit
 	if f, ok := CasListMap()[casType]; ok {
 		// if a cas-type is found, run it and return the error
@@ -78,7 +78,7 @@ func Describe(storages []string, openebsNs, casType string) error {
 		return errors.New("please provide atleast one pv name to describe")
 	}
 	// 1. Create the clientset
-	k, _ := client.NewK8sClient(openebsNs)
+	k := client.NewK8sClient(openebsNs)
 	// 2. Get the namespace
 	nsMap, _ := k.GetOpenEBSNamespaceMap()
 	if openebsNs == "" {

--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -102,10 +102,10 @@ var (
 	// CasTypeAndComponentNameMap stores the component name of the corresponding cas type
 	// NOTE: Not including ZFSLocalPV as it'd break existing code
 	CasTypeAndComponentNameMap = map[string]string{
-		CstorCasType:          CStorCSIControllerLabelValue,
-		JivaCasType:           JivaCSIControllerLabelValue,
-		LVMCasType:            LVMLocalPVcsiControllerLabelValue,
-		ZFSCasType:            ZFSLocalPVcsiControllerLabelValue,
+		CstorCasType:           CStorCSIControllerLabelValue,
+		JivaCasType:            JivaCSIControllerLabelValue,
+		LVMCasType:             LVMLocalPVcsiControllerLabelValue,
+		ZFSCasType:             ZFSLocalPVcsiControllerLabelValue,
 		LocalPvHostpathCasType: HostpathComponentNames,
 	}
 	// ComponentNameToCasTypeMap is a reverse map of CasTypeAndComponentNameMap

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -33,7 +33,7 @@ func Get(vols []string, openebsNS, casType string) error {
 		return fmt.Errorf("cas-type %s is not supported", casType)
 	}
 	// TODO: Prefer passing the client from outside
-	k, _ := client.NewK8sClient("")
+	k := client.NewK8sClient()
 	// 1. Get a list of required PersistentVolumes
 	var pvList *corev1.PersistentVolumeList
 	var err error
@@ -77,7 +77,7 @@ func Describe(vols []string, openebsNs string) error {
 		return errors.New("please provide atleast one pv name to describe")
 	}
 	// Clienset creation
-	k, _ := client.NewK8sClient(openebsNs)
+	k := client.NewK8sClient(openebsNs)
 
 	// 1. Get a list of required PersistentVolumes
 	var pvList *corev1.PersistentVolumeList


### PR DESCRIPTION
Signed-off-by: Abhishek-kumar09 <abhimait1909@gmail.com>
In the case of wrong kubeconfig, or no kubeconfig or no kubernetes the client initialisation throws error which are not handled by the current code at multiple places resulting in panic by CLI. 
- [x] Wrapped the client initialization with error-handling implicitly. 
- [x] Made namespace as optional argument, so that if we don't want to provide namespace and want to search in all namespaces we can omit passing empty string in functional arguments