### PR TITLE
Add support for creating a CSPC template

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,3 +30,4 @@ enable:
     - goimports
     - golint
     - misspell
+    - goheader

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -52,7 +52,8 @@ func NewCmdGenerateStorage() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&nodes, "nodes", "", "",
 		"comma separated set of nodes for pool creation --nodes=node1,node2,node3,node4")
 	cmd.MarkPersistentFlagRequired("nodes")
-	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "--number-of-devices=2")
-	cmd.PersistentFlags().StringVarP(&raidType, "raidtype", "", "stripe", "--raidtype=mirrored")
+	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "number of devices per node")
+	cmd.PersistentFlags().StringVarP(&raidType, "raidtype", "", "stripe",
+		"allowed RAID configuration such as, stripe, mirror, raid, raidz2")
 	return cmd
 }

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -51,7 +51,7 @@ func NewCmdGenerateStorage() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVarP(&nodes, "nodes", "", "",
 		"comma separated set of nodes for pool creation --nodes=node1,node2,node3,node4")
-	cmd.MarkPersistentFlagRequired("nodes")
+	_ = cmd.MarkPersistentFlagRequired("nodes")
 	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "number of devices per node")
 	cmd.PersistentFlags().StringVarP(&raidType, "raidtype", "", "stripe",
 		"allowed RAID configuration such as, stripe, mirror, raid, raidz2")

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generate
+
+import (
+	"strings"
+
+	"github.com/openebs/openebsctl/pkg/generate"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdGenerate provides options for generating
+func NewCmdGenerate() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:       "generate",
+		ValidArgs: []string{"cspc"},
+		Short:     "Generate one or more OpenEBS resources based on flags",
+	}
+	cmd.AddCommand(NewCmdGenerateStorage())
+	return cmd
+}
+
+func NewCmdGenerateStorage() *cobra.Command {
+	var nodes, raidType string
+	var devices int
+	cmd := &cobra.Command{
+		Use:   "cspc",
+		Short: "Displays status information about Volume(s)",
+		Run: func(cmd *cobra.Command, args []string) {
+			node, _ := cmd.Flags().GetString("nodes")
+			devs, _ := cmd.Flags().GetInt("number-of-devices")
+			raid, _ := cmd.Flags().GetString("raidtype")
+			Nodes := strings.Split(node, ",")
+			util.CheckErr(generate.Pool(Nodes, devs, raid), util.Fatal)
+		},
+	}
+	cmd.PersistentFlags().StringVarP(&nodes, "nodes", "", "",
+		"comma separated set of nodes for pool creation --nodes=node1,node2,node3,node4")
+	cmd.MarkPersistentFlagRequired("nodes")
+	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "--number-of-devices=2")
+	cmd.PersistentFlags().StringVarP(&raidType, "raidtype", "", "stripe", "--raidtype=mirrored")
+	return cmd
+}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generate
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/openebs/openebsctl/pkg/generate"
@@ -28,32 +29,62 @@ import (
 func NewCmdGenerate() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:       "generate",
+		Short:     "Generate one or more OpenEBS resource like cspc",
 		ValidArgs: []string{"cspc"},
-		Short:     "Generate one or more OpenEBS resources based on flags",
 	}
-	cmd.AddCommand(NewCmdGenerateStorage())
+	cmd.AddCommand(NewCmdGenerateCStorStoragePoolCluster())
 	return cmd
 }
 
-func NewCmdGenerateStorage() *cobra.Command {
+// NewCmdGenerateCStorStoragePoolCluster provides options for generating cspc
+// NOTE: When other custom resources need to be generated, the function
+// should be renamed appropriately, as of now it made no sense to generically
+// state pools when other pools aren't supported.
+func NewCmdGenerateCStorStoragePoolCluster() *cobra.Command {
 	var nodes, raidType string
 	var devices int
 	cmd := &cobra.Command{
-		Use:   "cspc",
-		Short: "Displays status information about Volume(s)",
+		Use:     "cspc",
+		Short:   "Generates cspc resources YAML/configuration which can be used to provision cStor storage pool clusters",
 		Run: func(cmd *cobra.Command, args []string) {
 			node, _ := cmd.Flags().GetString("nodes")
-			devs, _ := cmd.Flags().GetInt("number-of-devices")
 			raid, _ := cmd.Flags().GetString("raidtype")
-			Nodes := strings.Split(node, ",")
-			util.CheckErr(generate.Pool(Nodes, devs, raid), util.Fatal)
+			devs := numDevices(cmd)
+			nodeList := strings.Split(node, ",")
+			util.CheckErr(generate.CSPC(nodeList, devs, raid), util.Fatal)
 		},
 	}
 	cmd.PersistentFlags().StringVarP(&nodes, "nodes", "", "",
 		"comma separated set of nodes for pool creation --nodes=node1,node2,node3,node4")
 	_ = cmd.MarkPersistentFlagRequired("nodes")
-	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "number of devices per node")
 	cmd.PersistentFlags().StringVarP(&raidType, "raidtype", "", "stripe",
 		"allowed RAID configuration such as, stripe, mirror, raid, raidz2")
+	cmd.PersistentFlags().IntVar(&devices, "number-of-devices", 1, "number of devices per node, selects default based on raid-type")
 	return cmd
+}
+
+// numDevices figures out the number of devices based on the raid type
+func numDevices(cmd *cobra.Command) int {
+	// if number-of-devices is not set, set it to appropriate value
+	if !cmd.Flag("number-of-devices").Changed {
+		var devCount = map[string]int{
+			"stripe": 1,
+			"mirror": 2,
+			"raidz":  3,
+			"raidz2": 4}
+		switch cmd.Flag("raidtype").Value.String() {
+		case "stripe", "mirror", "raidz", "raidz2":
+			c := devCount[cmd.Flag("raidtype").Value.String()]
+			err := cmd.Flags().Set("number-of-devices", strconv.Itoa(c))
+			if err != nil {
+				return 1
+			}
+			return c
+		}
+	} else {
+		d, _ := cmd.Flags().GetInt("number-of-devices")
+		return d
+	}
+	// setting default value to 1
+	return 1
 }

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -20,16 +20,15 @@ import (
 	"flag"
 
 	cluster_info "github.com/openebs/openebsctl/cmd/cluster-info"
-	"github.com/openebs/openebsctl/cmd/upgrade"
-	"github.com/openebs/openebsctl/pkg/util"
-
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	"github.com/openebs/openebsctl/cmd/completion"
 	"github.com/openebs/openebsctl/cmd/describe"
+	"github.com/openebs/openebsctl/cmd/generate"
 	"github.com/openebs/openebsctl/cmd/get"
+	"github.com/openebs/openebsctl/cmd/upgrade"
 	v "github.com/openebs/openebsctl/cmd/version"
+	"github.com/openebs/openebsctl/pkg/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -39,6 +38,7 @@ const (
 Available Commands:
   completion    Outputs shell completion code for the specified shell (bash or zsh)
   describe      Provide detailed information about an OpenEBS resource
+  generate      Helps generate a storage custom resource
   get           Provides fetching operations related to a Volume/Pool
   help          Help about any command
   version       Shows openebs kubectl plugin's version
@@ -83,6 +83,7 @@ Find out more about OpenEBS on https://openebs.io/`,
 		v.NewCmdVersion(cmd),
 		cluster_info.NewCmdClusterInfo(cmd),
 		upgrade.NewCmdVolumeUpgrade(cmd),
+		generate.NewCmdGenerate(),
 	)
 	cmd.PersistentFlags().StringVarP(&openebsNs, "openebs-namespace", "", "", "to read the openebs namespace from user.\nIf not provided it is determined from components.")
 	cmd.PersistentFlags().StringVarP(&util.Kubeconfig, "kubeconfig", "c", "", "path to config file")

--- a/cmd/openebs.go
+++ b/cmd/openebs.go
@@ -39,7 +39,7 @@ Available Commands:
   completion    Outputs shell completion code for the specified shell (bash or zsh)
   describe      Provide detailed information about an OpenEBS resource
   generate      Helps generate a storage custom resource
-  get           Provides fetching operations related to a Volume/Pool
+  get           Provides fetching operations related to a Volume/CSPC
   help          Help about any command
   version       Shows openebs kubectl plugin's version
   cluster-info  Show component version, status and running components for each installed engine

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -506,7 +506,7 @@ func (k K8sClient) GetNodes(nodes []string, label, field string) (*corev1.NodeLi
 	if len(nodes) == 0 {
 		return n, err
 	}
-	// 2. Put them in a map[string]*corev1.Node
+	// 2. Put them in a map[string]corev1.Node
 	nodeMap := make(map[string]corev1.Node)
 	for _, item := range n.Items {
 		nodeMap[item.Name] = item

--- a/pkg/client/k8s.go
+++ b/pkg/client/k8s.go
@@ -267,18 +267,6 @@ func (k K8sClient) GetAllPods(namespace string) (*corev1.PodList, error) {
 	return pods, nil
 }
 
-// GetDeploymentList returns the deployment-list with a specific
-// label selector query
-func (k K8sClient) GetDeploymentList(labelSelector string) (*appsv1.DeploymentList, error) {
-	if pv, err := k.K8sCS.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: labelSelector,
-	}); err == nil && len(pv.Items) >= 1 {
-		return pv, nil
-	} else {
-		return nil, fmt.Errorf("got 0 deployments with label-Selector as %s", labelSelector)
-	}
-}
-
 // GetSC returns a StorageClass object using the scName passed.
 func (k K8sClient) GetSC(scName string) (*v1.StorageClass, error) {
 	sc, err := k.K8sCS.StorageV1().StorageClasses().Get(context.TODO(), scName, metav1.GetOptions{})
@@ -492,4 +480,45 @@ func (k K8sClient) GetBatchJobs() (*batchV1.JobList, error) {
 // Delete a Batch Job by name
 func (k K8sClient) DeleteBatchJob(name string, namespace string) error {
 	return k.K8sCS.BatchV1().Jobs(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+/*
+	LOCAL VOLUMES SPECIFIC METHODS
+*/
+
+// GetDeploymentList returns the deployment-list with a specific
+// label selector query
+func (k K8sClient) GetDeploymentList(labelSelector string) (*appsv1.DeploymentList, error) {
+	if pv, err := k.K8sCS.AppsV1().Deployments("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}); err == nil && len(pv.Items) >= 1 {
+		return pv, nil
+	}
+	return nil, fmt.Errorf("got 0 deployments with label-Selector as %s", labelSelector)
+}
+
+// GetNodes returns a list of nodes with the name of nodes
+func (k K8sClient) GetNodes(nodes []string, label, field string) (*corev1.NodeList, error) {
+	// 1. Get all nodes
+	n, err := k.K8sCS.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+		LabelSelector: label,
+		FieldSelector: field})
+	if len(nodes) == 0 {
+		return n, err
+	}
+	// 2. Put them in a map[string]*corev1.Node
+	nodeMap := make(map[string]corev1.Node)
+	for _, item := range n.Items {
+		nodeMap[item.Name] = item
+	}
+	// 3. Get the nodes by the name nodes
+	var items []corev1.Node
+	for _, name := range nodes {
+		if _, ok := nodeMap[name]; ok {
+			items = append(items, nodeMap[name])
+		}
+	}
+	return &corev1.NodeList{
+		Items: items,
+	}, nil
 }

--- a/pkg/generate/cspc.go
+++ b/pkg/generate/cspc.go
@@ -140,10 +140,14 @@ func getBDComment(name string, bdList *v1alpha1.BlockDeviceList) string {
 // pool instance and a collection of blockdevices by nodes
 func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevice, nodes []string) (*[]cstorv1.PoolSpec, error) {
 	var spec []cstorv1.PoolSpec
-	if poolType == string(cstorv1.PoolStriped) {
+	if poolType == string(cstorv1.PoolStriped) || poolType == string(cstorv1.PoolMirrored) {
 		// always a single RAID-group with nDevices patched together, cannot disk replace,
 		// no redundancy in a pool, redundancy possible across pool instances
-
+		if poolType == string(cstorv1.PoolMirrored) && nDevices%2 != 0 {
+			// 2ⁿ devices per RaidGroup, (confirm) not more than 2 devices per RaidGroup
+			// DOUBT: Should this throw an error if nDevices isn't 2ⁿ?
+			return nil, fmt.Errorf("mirrored pool requires multiples of two block device")
+		}
 		// for each eligible set of BDs from each eligible node, take nDevices number of BDs
 		for _, node := range nodes {
 			bds := bd[node]
@@ -155,33 +159,11 @@ func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevi
 				NodeSelector:   map[string]string{"kubernetes.io/hostname": node},
 				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: raids}},
 				PoolConfig: cstorv1.PoolConfig{
-					DataRaidGroupType: string(cstorv1.PoolStriped),
+					DataRaidGroupType: poolType,
 				},
 			})
 		}
 		return &spec, nil
-	} else if poolType == string(cstorv1.PoolMirrored) {
-		if nDevices%2 != 0 {
-			return nil, fmt.Errorf("mirrored pool requires multiples of two block device")
-		}
-		for node, bds := range bd {
-			var raids []cstorv1.CStorPoolInstanceBlockDevice
-			// add all BDs to a CSPCs CSPI spec
-			for d := 0; d < nDevices; d++ {
-				raids = append(raids, cstorv1.CStorPoolInstanceBlockDevice{BlockDeviceName: bds[d].Name})
-			}
-			// add the CSPI BD spec inside CSPC to a PoolSpec
-			spec = append(spec, cstorv1.PoolSpec{
-				NodeSelector:   map[string]string{"kubernetes.io/hostname": node},
-				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: raids}},
-				PoolConfig: cstorv1.PoolConfig{
-					DataRaidGroupType: string(cstorv1.PoolMirrored),
-				},
-			})
-		}
-		return &spec, nil
-		// 2ⁿ devices per RaidGroup, (confirm) not more than 2 devices per RaidGroup
-		// DOUBT: Should this throw an error if nDevices isn't 2ⁿ?
 	} else if poolType == string(cstorv1.PoolRaidz) {
 		return nil, fmt.Errorf("%s is not supported yet", poolType)
 		// 2ⁿ+1 devices per RaidGroup

--- a/pkg/generate/cspc.go
+++ b/pkg/generate/cspc.go
@@ -1,0 +1,90 @@
+package generate
+
+import (
+	"fmt"
+	"strings"
+
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/openebsctl/pkg/client"
+	"github.com/openebs/openebsctl/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// isPoolValid checks if a CStor pool is valid
+func isPoolTypeValid(raid string) bool {
+	if raid == "stripe" || raid == "mirror" || raid == "raidz" || raid == "raidz2" {
+		return true
+	} else {
+		return false
+	}
+}
+
+// Pool calls the generate routine for different cas-types
+func Pool(nodes []string, devs int, raid string) error {
+	c, _ := client.NewK8sClient("")
+	_, _, err := CSPC(c, nodes, devs, strings.ToLower(raid))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// CSPC takes eligible nodes, number of devices and poolType to create a pool cluster template
+func CSPC(c *client.K8sClient, nodes []string, devs int, poolType string) (*cstorv1.CStorPoolCluster, string, error) {
+	// 0. Figure out the OPENEBS_NAMESPACE for CStor
+	cstorNS, err := c.GetOpenEBSNamespace(util.CstorCasType)
+	// assume CSTOR's OPENEBS_NAMESPACE has all the relevant blockdevices
+	c.Ns = cstorNS
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot find an active cstor installation")
+	}
+	// 1. Validate nodes & poolType, fetch disks
+	nodeList, err := c.GetNodes(nodes, "", "")
+	if err != nil {
+		return nil, "", fmt.Errorf("(server error) unable to fetch nodes %s", err)
+	}
+	if len(nodeList.Items) != len(nodes) {
+		return nil, "", fmt.Errorf("not all worker nodes are available for provisioning a CSPC")
+	}
+	bds, err := c.GetBDs(nil, "kubernetes.io/hostname in ("+strings.Join(nodes, ",")+")")
+	if err != nil || len(bds.Items) == 0 {
+		return nil, "", fmt.Errorf("no blockdevices found in %s nodes", nodes)
+	}
+	_, err = filterCStorCompatible(bds)
+	if err != nil {
+		return nil, "", fmt.Errorf("(server error) unable to fetch bds from %s nodes", nodes)
+	}
+	// 2. Choose devices at the valid nodes
+	// 3. Write the CSPC object with a dummy name
+	p := make([]cstorv1.PoolSpec, 0, len(nodes))
+	cspc := cstorv1.CStorPoolCluster{
+		TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: cstorNS, GenerateName: "cstor"},
+		Spec: cstorv1.CStorPoolClusterSpec{
+			Pools: p,
+		}}
+	// 4. Unmarshall it into a string
+	// 5. Split the string by the newlines/carriage returns and insert the BD's link
+	return &cspc, "", nil
+}
+
+// filterCStorCompatible takes a list of BDs and gives out a list of BDs which can be used to provision a pool
+func filterCStorCompatible(bds *v1alpha1.BlockDeviceList) (*v1alpha1.BlockDeviceList, error) {
+	var final []v1alpha1.BlockDevice
+	for _, bd := range bds.Items {
+		// an eligible blockdevice is in active+unclaimed state and lacks a file-system
+		if bd.Status.State == v1alpha1.BlockDeviceActive &&
+			bd.Status.ClaimState == v1alpha1.BlockDeviceUnclaimed &&
+			bd.Spec.FileSystem.Type == "" &&
+			// BD's capacity >=64 MiB
+			bd.Spec.Capacity.Storage >= 67110000 {
+			final = append(final, bd)
+		}
+	}
+	bds.Items = final
+	if len(final) == 0 {
+		return nil, fmt.Errorf("found no eligble blockdevices")
+	}
+	return bds, nil
+}

--- a/pkg/generate/cspc.go
+++ b/pkg/generate/cspc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package generate
 
 import (
@@ -21,17 +37,21 @@ func isPoolTypeValid(raid string) bool {
 }
 
 // Pool calls the generate routine for different cas-types
-func Pool(nodes []string, devs int, raid string) error {
+func Pool(nodes []string, devs, GB int, raid string) error {
 	c, _ := client.NewK8sClient("")
-	_, _, err := CSPC(c, nodes, devs, strings.ToLower(raid))
+	if !isPoolTypeValid(strings.ToLower(raid)) {
+		return fmt.Errorf("invalid pool type %s", raid)
+	}
+	_, str, err := CSPC(c, nodes, devs, GB, strings.ToLower(raid))
 	if err != nil {
 		return err
 	}
+	fmt.Println(str)
 	return nil
 }
 
 // CSPC takes eligible nodes, number of devices and poolType to create a pool cluster template
-func CSPC(c *client.K8sClient, nodes []string, devs int, poolType string) (*cstorv1.CStorPoolCluster, string, error) {
+func CSPC(c *client.K8sClient, nodes []string, devs, minGB int, poolType string) (*cstorv1.CStorPoolCluster, string, error) {
 	// 0. Figure out the OPENEBS_NAMESPACE for CStor
 	cstorNS, err := c.GetOpenEBSNamespace(util.CstorCasType)
 	// assume CSTOR's OPENEBS_NAMESPACE has all the relevant blockdevices
@@ -56,21 +76,65 @@ func CSPC(c *client.K8sClient, nodes []string, devs int, poolType string) (*csto
 		return nil, "", fmt.Errorf("(server error) unable to fetch bds from %s nodes", nodes)
 	}
 	// 2. Choose devices at the valid nodes
-	// 3. Write the CSPC object with a dummy name
-	p := make([]cstorv1.PoolSpec, 0, len(nodes))
+	nodeToBD := make(map[string][]v1alpha1.BlockDevice)
+	for _, bd := range bds.Items {
+		nodeToBD[bd.Labels["kubernetes.io/hostname"]] = append(nodeToBD[bd.Labels["kubernetes.io/hostname"]], bd)
+	}
+	// 3. Select disks
+	p, err := makePools(poolType, devs, nodeToBD)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// 4. Write the CSPC object with a dummy name
 	cspc := cstorv1.CStorPoolCluster{
 		TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: cstorNS, GenerateName: "cstor"},
 		Spec: cstorv1.CStorPoolClusterSpec{
-			Pools: p,
+			Pools: *p,
 		}}
-	// 4. Unmarshall it into a string
-	// 5. Split the string by the newlines/carriage returns and insert the BD's link
+	// 5. Unmarshall it into a string
+	// 6. Split the string by the newlines/carriage returns and insert the BD's link
 	return &cspc, "", nil
+}
+
+func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevice) (*[]cstorv1.PoolSpec, error) {
+	var spec []cstorv1.PoolSpec
+	if poolType == string(cstorv1.PoolStriped) {
+		// always a single RAID-group with nDevices patched together, cannot disk replace,
+		// no redundancy in a pool, redundancy possible across pool instances
+
+		// for each eligible set of BDs from each eligible node, take nDevices number of BDs
+		for node, bds := range bd {
+			var raid cstorv1.RaidGroup
+			for d := 0; d < nDevices; d++ {
+				raid = cstorv1.RaidGroup{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{
+					{BlockDeviceName: bds[d].Name},
+				}}
+			}
+			spec = append(spec, cstorv1.PoolSpec{
+				NodeSelector:  map[string]string{"kubernetes.io/hostname": node} ,
+				DataRaidGroups: []cstorv1.RaidGroup{raid},
+				PoolConfig:     cstorv1.PoolConfig{
+					DataRaidGroupType: string(cstorv1.PoolStriped),
+				},
+			})	
+		}
+		return &spec, nil
+	} else if poolType == string(cstorv1.PoolMirrored) {
+		// 2ⁿ devices per RaidGroup, (confirm) not more than 2 devices per RaidGroup
+		// DOUBT: Should this throw an error if nDevices isn't 2ⁿ?
+	} else if poolType == string(cstorv1.PoolRaidz) {
+		// 2ⁿ⁺¹ devices per RaidGroup
+	} else if poolType == string(cstorv1.PoolRaidz2) {
+		// 2ⁿ⁺² devices per RaidGroup
+	}
+	return nil, fmt.Errorf("unknown pool-type")
 }
 
 // filterCStorCompatible takes a list of BDs and gives out a list of BDs which can be used to provision a pool
 func filterCStorCompatible(bds *v1alpha1.BlockDeviceList) (*v1alpha1.BlockDeviceList, error) {
+	// TODO: Optionally reject sparse-disks depending on configs
 	var final []v1alpha1.BlockDevice
 	for _, bd := range bds.Items {
 		// an eligible blockdevice is in active+unclaimed state and lacks a file-system

--- a/pkg/generate/cspc.go
+++ b/pkg/generate/cspc.go
@@ -147,14 +147,13 @@ func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevi
 		// for each eligible set of BDs from each eligible node, take nDevices number of BDs
 		for _, node := range nodes {
 			bds := bd[node]
-			var raid cstorv1.RaidGroup
+			var raids []cstorv1.CStorPoolInstanceBlockDevice
 			for d := 0; d < nDevices; d++ {
-				raid = cstorv1.RaidGroup{
-					CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: bds[d].Name}}}
+				raids = append(raids, cstorv1.CStorPoolInstanceBlockDevice{BlockDeviceName: bds[d].Name})
 			}
 			spec = append(spec, cstorv1.PoolSpec{
 				NodeSelector:   map[string]string{"kubernetes.io/hostname": node},
-				DataRaidGroups: []cstorv1.RaidGroup{raid},
+				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: raids}},
 				PoolConfig: cstorv1.PoolConfig{
 					DataRaidGroupType: string(cstorv1.PoolStriped),
 				},

--- a/pkg/generate/cspc.go
+++ b/pkg/generate/cspc.go
@@ -140,14 +140,10 @@ func getBDComment(name string, bdList *v1alpha1.BlockDeviceList) string {
 // pool instance and a collection of blockdevices by nodes
 func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevice, nodes []string) (*[]cstorv1.PoolSpec, error) {
 	var spec []cstorv1.PoolSpec
-	if poolType == string(cstorv1.PoolStriped) || poolType == string(cstorv1.PoolMirrored) {
+	if poolType == string(cstorv1.PoolStriped) {
 		// always a single RAID-group with nDevices patched together, cannot disk replace,
 		// no redundancy in a pool, redundancy possible across pool instances
-		if poolType == string(cstorv1.PoolMirrored) && nDevices%2 != 0 {
-			// 2ⁿ devices per RaidGroup, (confirm) not more than 2 devices per RaidGroup
-			// DOUBT: Should this throw an error if nDevices isn't 2ⁿ?
-			return nil, fmt.Errorf("mirrored pool requires multiples of two block device")
-		}
+
 		// for each eligible set of BDs from each eligible node, take nDevices number of BDs
 		for _, node := range nodes {
 			bds := bd[node]
@@ -159,11 +155,33 @@ func makePools(poolType string, nDevices int, bd map[string][]v1alpha1.BlockDevi
 				NodeSelector:   map[string]string{"kubernetes.io/hostname": node},
 				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: raids}},
 				PoolConfig: cstorv1.PoolConfig{
-					DataRaidGroupType: poolType,
+					DataRaidGroupType: string(cstorv1.PoolStriped),
 				},
 			})
 		}
 		return &spec, nil
+	} else if poolType == string(cstorv1.PoolMirrored) {
+		if nDevices%2 != 0 {
+			return nil, fmt.Errorf("mirrored pool requires multiples of two block device")
+		}
+		for node, bds := range bd {
+			var raids []cstorv1.CStorPoolInstanceBlockDevice
+			// add all BDs to a CSPCs CSPI spec
+			for d := 0; d < nDevices; d++ {
+				raids = append(raids, cstorv1.CStorPoolInstanceBlockDevice{BlockDeviceName: bds[d].Name})
+			}
+			// add the CSPI BD spec inside CSPC to a PoolSpec
+			spec = append(spec, cstorv1.PoolSpec{
+				NodeSelector:   map[string]string{"kubernetes.io/hostname": node},
+				DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: raids}},
+				PoolConfig: cstorv1.PoolConfig{
+					DataRaidGroupType: string(cstorv1.PoolMirrored),
+				},
+			})
+		}
+		return &spec, nil
+		// 2ⁿ devices per RaidGroup, (confirm) not more than 2 devices per RaidGroup
+		// DOUBT: Should this throw an error if nDevices isn't 2ⁿ?
 	} else if poolType == string(cstorv1.PoolRaidz) {
 		return nil, fmt.Errorf("%s is not supported yet", poolType)
 		// 2ⁿ+1 devices per RaidGroup

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package generate
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -154,6 +155,7 @@ func Test_makePools(t *testing.T) {
 		nDevices int
 		bd       map[string][]v1alpha1.BlockDevice
 		nodes    []string
+		hosts 	 []string
 	}
 	tests := []struct {
 		name    string
@@ -164,24 +166,27 @@ func Test_makePools(t *testing.T) {
 		{"stripe, three node, two disks", args{"stripe", 2,
 			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1},
 				"node2": {goodBD1N2, goodBD2N2}, "node3": {goodBD1N3, goodBD2N3}},
-			[]string{"node1", "node2", "node3"}}, &threeNodeTwoDevCSPC.Spec.Pools, false},
+			[]string{"node1", "node2", "node3"}, []string{"node1", "node2", "node3"}}, &threeNodeTwoDevCSPC.Spec.Pools, false},
 		{"mirror, three node, two disks", args{"mirror", 2,
 			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1},
 				"node2": {goodBD1N2, goodBD2N2}, "node3": {goodBD1N3, goodBD2N3}},
-			[]string{"node1", "node2", "node3"}}, &mirrorCSPC.Spec.Pools, false},
+			[]string{"node1", "node2", "node3"}, []string{"node1", "node2", "node3"}}, &mirrorCSPC.Spec.Pools, false},
 		{"mirror, three node, one disk", args{"mirror", 1,
 			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1},
 				"node2": {goodBD1N2, goodBD2N2}, "node3": {goodBD1N3, goodBD2N3}},
-			[]string{"node1", "node2", "node3"}}, nil, true},
+			[]string{"node1", "node2", "node3"}, []string{"node1", "node2", "node3"}}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := makePools(tt.args.poolType, tt.args.nDevices, tt.args.bd, tt.args.nodes)
+			got, err := makePools(tt.args.poolType, tt.args.nDevices, tt.args.bd, tt.args.nodes, tt.args.hosts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("makePools() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			assert.EqualValues(t, tt.want, got, "", nil)
+			if (tt.want == got) {
+				fmt.Println("yay")
+			}
+			assert.Equal(t, tt.want, got, "", nil)
 		})
 	}
 }

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -1,0 +1,84 @@
+package generate
+
+import (
+	"reflect"
+	"testing"
+
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	cstorfake "github.com/openebs/api/v2/pkg/client/clientset/versioned/fake"
+	"github.com/openebs/openebsctl/pkg/client"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCSPC(t *testing.T) {
+	type args struct {
+		c        *client.K8sClient
+		nodes    []string
+		devs     int
+		poolType string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cstorv1.CStorPoolCluster
+		str     string
+		wantErr bool
+	}{
+		{
+			"no cstor installation present",
+			args{
+				c:     &client.K8sClient{Ns: "", K8sCS: fake.NewSimpleClientset(), OpenebsCS: cstorfake.NewSimpleClientset()},
+				nodes: []string{"node1"}, devs: 1, poolType: ""}, &cstorv1.CStorPoolCluster{},
+			"", true,
+		},
+		{
+			"stripe kind CSPC with one block-device",
+			args{
+				c:     &client.K8sClient{Ns: "openebs", K8sCS: fake.NewSimpleClientset(), OpenebsCS: cstorfake.NewSimpleClientset()},
+				nodes: []string{"node1"}, devs: 1, poolType: ""}, &cstorv1.CStorPoolCluster{},
+			"", false,
+		},
+		{
+			"stripe kind CSPC with two block-device on different nodes",
+			args{
+				c:     &client.K8sClient{Ns: "openebs", K8sCS: fake.NewSimpleClientset(), OpenebsCS: cstorfake.NewSimpleClientset()},
+				nodes: []string{"node1"}, devs: 1, poolType: ""}, &cstorv1.CStorPoolCluster{},
+			"", false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := CSPC(tt.args.c, tt.args.nodes, tt.args.devs, tt.args.poolType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CSPC() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CSPC() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.str {
+				t.Errorf("CSPC() got1 = %v, want %v", got1, tt.str)
+			}
+		})
+	}
+}
+
+func Test_isPoolTypeValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		poolNames []string
+		want      bool
+	}{
+		{name: "valid pools", poolNames: []string{"stripe", "mirror", "raidz", "raidz2"}, want: true},
+		{name: "invalid pools", poolNames: []string{"striped", "mirrored", "raid-z", "raid-z2", "lvm"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, poolType := range tt.poolNames {
+				if got := isPoolTypeValid(poolType); got != tt.want {
+					t.Errorf("isPoolTypeValid() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -171,6 +171,11 @@ func Test_makePools(t *testing.T) {
 			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1},
 				"node2": {goodBD1N2, goodBD2N2}, "node3": {goodBD1N3, goodBD2N3}},
 			[]string{"node1", "node2", "node3"}, []string{"node1", "node2", "node3"}}, &mirrorCSPC.Spec.Pools, false},
+		{"mirror, two node, four disks", args{"mirror", 4,
+			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1, goodBD3N1, goodBD4N1},
+				"node2": {goodBD1N2, goodBD2N2, goodBD3N2, goodBD4N2}, "node3": {goodBD1N3, goodBD2N3}},
+				// in the above example, presence of node3 BDs don't matter
+			[]string{"node1", "node2"}, []string{"node1", "node2"}}, &mirrorCSPCFourBDs.Spec.Pools, false},
 		{"mirror, three node, one disk", args{"mirror", 1,
 			map[string][]v1alpha1.BlockDevice{"node1": {goodBD1N1, goodBD2N1},
 				"node2": {goodBD1N2, goodBD2N2}, "node3": {goodBD1N3, goodBD2N3}},
@@ -183,7 +188,7 @@ func Test_makePools(t *testing.T) {
 				t.Errorf("makePools() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if (tt.want == got) {
+			if tt.want == got {
 				fmt.Println("yay")
 			}
 			assert.Equal(t, tt.want, got, "", nil)

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -65,7 +65,8 @@ func TestCSPC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := CSPC(tt.args.c, tt.args.nodes, tt.args.GB, tt.args.devs, tt.args.poolType)
+			// tt.args.GB,
+			got, got1, err := CSPC(tt.args.c, tt.args.nodes, tt.args.devs, tt.args.poolType)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CSPC() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package generate
 
 import (
@@ -15,6 +31,7 @@ func TestCSPC(t *testing.T) {
 		c        *client.K8sClient
 		nodes    []string
 		devs     int
+		GB       int
 		poolType string
 	}
 	tests := []struct {
@@ -28,7 +45,7 @@ func TestCSPC(t *testing.T) {
 			"no cstor installation present",
 			args{
 				c:     &client.K8sClient{Ns: "", K8sCS: fake.NewSimpleClientset(), OpenebsCS: cstorfake.NewSimpleClientset()},
-				nodes: []string{"node1"}, devs: 1, poolType: ""}, &cstorv1.CStorPoolCluster{},
+				nodes: []string{"node1"}, devs: 1, poolType: ""}, nil,
 			"", true,
 		},
 		{
@@ -48,7 +65,7 @@ func TestCSPC(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1, err := CSPC(tt.args.c, tt.args.nodes, tt.args.devs, tt.args.poolType)
+			got, got1, err := CSPC(tt.args.c, tt.args.nodes, tt.args.GB, tt.args.devs, tt.args.poolType)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CSPC() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/generate/cspc_test.go
+++ b/pkg/generate/cspc_test.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-
-
 func TestCSPC(t *testing.T) {
 	type args struct {
 		c        *client.K8sClient
@@ -86,6 +84,13 @@ func TestCSPC(t *testing.T) {
 				c: &client.K8sClient{Ns: "randomNamespaceWillGetReplaced", K8sCS: fake.NewSimpleClientset(&cstorCSIpod, &node1),
 					OpenebsCS: cstorfake.NewSimpleClientset(&activeUnclaimedUnforattedBD)},
 				nodes: []string{"node1"}, devs: 1, poolType: "stripe"}, &cspc1Struct, cspc1, false,
+		},
+		{
+			"all good config, 2 disk stripe pool for 3 nodes",
+			args{
+				c: &client.K8sClient{Ns: "", K8sCS: fake.NewSimpleClientset(&cstorCSIpod, &node1, &node2, &node3),
+					OpenebsCS: cstorfake.NewSimpleClientset(&goodBD1N1, &goodBD1N2, &goodBD1N3, &goodBD2N1, &goodBD2N2, &goodBD2N3)},
+				nodes: []string{"node1", "node2", "node3"}, devs: 2, poolType: "stripe"}, &threeNodeTwoDevCSPC, StripeThreeNodeTwoDev, false,
 		},
 		{
 			"good config, no BDs",

--- a/pkg/generate/testdata_test.go
+++ b/pkg/generate/testdata_test.go
@@ -31,15 +31,15 @@ var cstorCSIpod = corev1.Pod{
 }
 
 var node1 = corev1.Node{
-	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
 	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
 
 var node2 = corev1.Node{
-	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
 	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
 
 var node3 = corev1.Node{
-	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node3"},
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node3", Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
 	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
 
 var activeBDwEXT4 = v1alpha1.BlockDevice{

--- a/pkg/generate/testdata_test.go
+++ b/pkg/generate/testdata_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020-2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package generate
 
 import (
@@ -16,13 +32,11 @@ var cstorCSIpod = corev1.Pod{
 
 var node1 = corev1.Node{
 	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node1"},
-	Status: corev1.NodeStatus{Phase: corev1.NodeRunning},
-}
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
 
 var node2 = corev1.Node{
 	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node2"},
-	Status: corev1.NodeStatus{Phase: corev1.NodeRunning},
-}
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
 
 var node3 = corev1.Node{
 	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node3"},
@@ -33,8 +47,7 @@ var activeBDwEXT4 = v1alpha1.BlockDevice{
 	ObjectMeta: metav1.ObjectMeta{Name: "bd1", Namespace: "openebs",
 		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
 	Spec:   v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "ext4", Mountpoint: "/dev/sda"}},
-	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive},
-}
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
 
 var inactiveBDwEXT4 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
@@ -58,6 +71,7 @@ var goodBD1N1 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD2N1 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n1", Namespace: "openebs",
@@ -65,6 +79,7 @@ var goodBD2N1 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd2n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD1N2 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n2", Namespace: "openebs",
@@ -72,6 +87,7 @@ var goodBD1N2 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD2N2 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n2", Namespace: "openebs",
@@ -79,6 +95,7 @@ var goodBD2N2 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD1N3 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n3", Namespace: "openebs",
@@ -86,6 +103,7 @@ var goodBD1N3 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sdc"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD2N3 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n3", Namespace: "openebs",
@@ -93,26 +111,19 @@ var goodBD2N3 = v1alpha1.BlockDevice{
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sdc"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
-var _ = v1alpha1.BlockDevice{
-	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
-	ObjectMeta: metav1.ObjectMeta{Name: "bd2", Namespace: "openebs",
-		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
-	Spec:   v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Path: "/dev/sda"},
-	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceInactive},
-}
 
 var mirrorCSPC = cstorv1.CStorPoolCluster{
 	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
 	ObjectMeta: metav1.ObjectMeta{GenerateName: "cstor", Namespace: "openebs"},
 	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{
 		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
-			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{
 				BlockDeviceName: "bd1-n1"}, {BlockDeviceName: "bd2-n1"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
 		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
-			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{
 				BlockDeviceName: "bd1-n2"}, {BlockDeviceName: "bd2-n2"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
 		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node3"},
-			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{
 				BlockDeviceName: "bd1-n3"}, {BlockDeviceName: "bd2-n3"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}}}
 
 var mirrorCSPCstr = `apiVersion: cstor.openebs.io/v1
@@ -125,9 +136,19 @@ spec:
   pools:
   - dataRaidGroups:
     - blockDevices:
-      # /dev/sda  1GB
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd1-n1
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd2-n1
+    nodeSelector:
+      kubernetes.io/hostname: node1
+    poolConfig:
+      dataRaidGroupType: mirror
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1.0GiB
       - blockDeviceName: bd1-n2
-      # /dev/sda  1GB
+      # /dev/sda  1.0GiB
       - blockDeviceName: bd2-n2
     nodeSelector:
       kubernetes.io/hostname: node2
@@ -135,24 +156,15 @@ spec:
       dataRaidGroupType: mirror
   - dataRaidGroups:
     - blockDevices:
-      # /dev/sda  1GB
+      # /dev/sda  1.0GiB
       - blockDeviceName: bd1-n3
-      # /dev/sda  1GB
+      # /dev/sda  1.0GiB
       - blockDeviceName: bd2-n3
     nodeSelector:
       kubernetes.io/hostname: node3
     poolConfig:
       dataRaidGroupType: mirror
-  - dataRaidGroups:
-    - blockDevices:
-      # /dev/sda  1GB
-      - blockDeviceName: bd1-n1
-      # /dev/sda  1GB
-      - blockDeviceName: bd2-n1
-    nodeSelector:
-      kubernetes.io/hostname: node1
-    poolConfig:
-      dataRaidGroupType: mirror
+
 `
 
 var cspc1 = `apiVersion: cstor.openebs.io/v1
@@ -165,7 +177,7 @@ spec:
   pools:
   - dataRaidGroups:
     - blockDevices:
-      # /dev/sda  1GB
+      # /dev/sda  1.0GiB
       - blockDeviceName: bd1
     nodeSelector:
       kubernetes.io/hostname: node1
@@ -180,6 +192,6 @@ var cspc1Struct = cstorv1.CStorPoolCluster{
 	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
 		NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
 		DataRaidGroups: []cstorv1.RaidGroup{{
-			[]cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1"}}}},
+			CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1"}}}},
 		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolStriped)}}}},
 }

--- a/pkg/generate/testdata_test.go
+++ b/pkg/generate/testdata_test.go
@@ -80,6 +80,22 @@ var goodBD2N1 = v1alpha1.BlockDevice{
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
 
+var goodBD3N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd3-n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd3n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var goodBD4N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd4-n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd4n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
 var goodBD1N2 = v1alpha1.BlockDevice{
 	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n2", Namespace: "openebs",
@@ -93,6 +109,22 @@ var goodBD2N2 = v1alpha1.BlockDevice{
 	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n2", Namespace: "openebs",
 		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
 	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var goodBD3N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd3-n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd3n2"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var goodBD4N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd4-n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd4n2"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
 		Path: "/dev/sda"},
 	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
 
@@ -125,6 +157,19 @@ var mirrorCSPC = cstorv1.CStorPoolCluster{
 		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node3"},
 			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{
 				BlockDeviceName: "bd1-n3"}, {BlockDeviceName: "bd2-n3"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}}}
+
+var mirrorCSPCFourBDs = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{GenerateName: "cstor", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1-n1"}, {BlockDeviceName: "bd2-n1"}}},
+				{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd3-n1"}, {BlockDeviceName: "bd4-n1"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
+			DataRaidGroups: []cstorv1.RaidGroup{{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1-n2"}, {BlockDeviceName: "bd2-n2"}}},
+				{CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd3-n2"}, {BlockDeviceName: "bd4-n2"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}}}
 
 var mirrorCSPCstr = `apiVersion: cstor.openebs.io/v1
 kind: CStorPoolCluster

--- a/pkg/generate/testdata_test.go
+++ b/pkg/generate/testdata_test.go
@@ -1,0 +1,185 @@
+package generate
+
+import (
+	cstorv1 "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	"github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var cstorCSIpod = corev1.Pod{
+	TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "fake-cstor-CSI", Namespace: "openebs",
+		Labels: map[string]string{"openebs.io/version": "1.9.0", "openebs.io/component-name": "openebs-cstor-csi-controller"}},
+	Status: corev1.PodStatus{Phase: corev1.PodRunning},
+}
+
+var node1 = corev1.Node{
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning},
+}
+
+var node2 = corev1.Node{
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning},
+}
+
+var node3 = corev1.Node{
+	TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "node3"},
+	Status: corev1.NodeStatus{Phase: corev1.NodeRunning}}
+
+var activeBDwEXT4 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec:   v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "ext4", Mountpoint: "/dev/sda"}},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive},
+}
+
+var inactiveBDwEXT4 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1-inactive", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec:   v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "ext4", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 6711000}},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceInactive}}
+
+var activeUnclaimedUnforattedBD = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+
+var goodBD1N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd1n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD2N1 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n1", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/mnt/bd2n1"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD1N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD2N2 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node2"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD1N3 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd1-n3", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sdc"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var goodBD2N3 = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2-n3", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node3"}},
+	Spec: v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sdc"}, Capacity: v1alpha1.DeviceCapacity{Storage: 1074000000},
+		Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceActive}}
+var _ = v1alpha1.BlockDevice{
+	TypeMeta: metav1.TypeMeta{Kind: "Blockdevice", APIVersion: "openebs.io/v1alpha1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "bd2", Namespace: "openebs",
+		Labels: map[string]string{"kubernetes.io/hostname": "node1"}},
+	Spec:   v1alpha1.DeviceSpec{FileSystem: v1alpha1.FileSystemInfo{Type: "", Mountpoint: "/dev/sda"}, Path: "/dev/sda"},
+	Status: v1alpha1.DeviceStatus{ClaimState: v1alpha1.BlockDeviceUnclaimed, State: v1alpha1.BlockDeviceInactive},
+}
+
+var mirrorCSPC = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{GenerateName: "cstor", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+				BlockDeviceName: "bd1-n1"}, {BlockDeviceName: "bd2-n1"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
+			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+				BlockDeviceName: "bd1-n2"}, {BlockDeviceName: "bd2-n2"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}},
+		{NodeSelector: map[string]string{"kubernetes.io/hostname": "node3"},
+			DataRaidGroups: []cstorv1.RaidGroup{{[]cstorv1.CStorPoolInstanceBlockDevice{{
+				BlockDeviceName: "bd1-n3"}, {BlockDeviceName: "bd2-n3"}}}}, PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolMirrored)}}}}}
+
+var mirrorCSPCstr = `apiVersion: cstor.openebs.io/v1
+kind: CStorPoolCluster
+metadata:
+  creationTimestamp: null
+  generateName: cstor
+  namespace: openebs
+spec:
+  pools:
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1GB
+      - blockDeviceName: bd1-n2
+      # /dev/sda  1GB
+      - blockDeviceName: bd2-n2
+    nodeSelector:
+      kubernetes.io/hostname: node2
+    poolConfig:
+      dataRaidGroupType: mirror
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1GB
+      - blockDeviceName: bd1-n3
+      # /dev/sda  1GB
+      - blockDeviceName: bd2-n3
+    nodeSelector:
+      kubernetes.io/hostname: node3
+    poolConfig:
+      dataRaidGroupType: mirror
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1GB
+      - blockDeviceName: bd1-n1
+      # /dev/sda  1GB
+      - blockDeviceName: bd2-n1
+    nodeSelector:
+      kubernetes.io/hostname: node1
+    poolConfig:
+      dataRaidGroupType: mirror
+`
+
+var cspc1 = `apiVersion: cstor.openebs.io/v1
+kind: CStorPoolCluster
+metadata:
+  creationTimestamp: null
+  generateName: cstor
+  namespace: openebs
+spec:
+  pools:
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1GB
+      - blockDeviceName: bd1
+    nodeSelector:
+      kubernetes.io/hostname: node1
+    poolConfig:
+      dataRaidGroupType: stripe
+
+`
+
+var cspc1Struct = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{GenerateName: "cstor", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+		DataRaidGroups: []cstorv1.RaidGroup{{
+			[]cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1"}}}},
+		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolStriped)}}}},
+}

--- a/pkg/generate/testdata_test.go
+++ b/pkg/generate/testdata_test.go
@@ -185,6 +185,65 @@ spec:
       dataRaidGroupType: stripe
 
 `
+var StripeThreeNodeTwoDev = `apiVersion: cstor.openebs.io/v1
+kind: CStorPoolCluster
+metadata:
+  creationTimestamp: null
+  generateName: cstor
+  namespace: openebs
+spec:
+  pools:
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd1-n1
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd2-n1
+    nodeSelector:
+      kubernetes.io/hostname: node1
+    poolConfig:
+      dataRaidGroupType: stripe
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd1-n2
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd2-n2
+    nodeSelector:
+      kubernetes.io/hostname: node2
+    poolConfig:
+      dataRaidGroupType: stripe
+  - dataRaidGroups:
+    - blockDevices:
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd1-n3
+      # /dev/sda  1.0GiB
+      - blockDeviceName: bd2-n3
+    nodeSelector:
+      kubernetes.io/hostname: node3
+    poolConfig:
+      dataRaidGroupType: stripe
+
+`
+var threeNodeTwoDevCSPC = cstorv1.CStorPoolCluster{
+	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{GenerateName: "cstor", Namespace: "openebs"},
+	Spec: cstorv1.CStorPoolClusterSpec{Pools: []cstorv1.PoolSpec{{
+		NodeSelector: map[string]string{"kubernetes.io/hostname": "node1"},
+		DataRaidGroups: []cstorv1.RaidGroup{{
+			CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1-n1"}, {BlockDeviceName: "bd2-n1"}}}},
+		PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolStriped)}},
+		{
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "node2"},
+			DataRaidGroups: []cstorv1.RaidGroup{{
+				CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1-n2"}, {BlockDeviceName: "bd2-n2"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolStriped)}},
+		{
+			NodeSelector: map[string]string{"kubernetes.io/hostname": "node3"},
+			DataRaidGroups: []cstorv1.RaidGroup{{
+				CStorPoolInstanceBlockDevices: []cstorv1.CStorPoolInstanceBlockDevice{{BlockDeviceName: "bd1-n3"}, {BlockDeviceName: "bd2-n3"}}}},
+			PoolConfig: cstorv1.PoolConfig{DataRaidGroupType: string(cstorv1.PoolStriped)}}}},
+}
 
 var cspc1Struct = cstorv1.CStorPoolCluster{
 	TypeMeta:   metav1.TypeMeta{Kind: "CStorPoolCluster", APIVersion: "cstor.openebs.io/v1"},


### PR DESCRIPTION
# Summary

For a k8s cluster which has CStor installed, this CLI takes some arguments and generates a Pool-Cluster YAML to help user create a CStor pool of a certain kind via flags

fixes: #58 

```bash
$ kubectl openebs generate cspc --nodes=shubham
apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  creationTimestamp: null
  generateName: cstor
  namespace: openebs
spec:
  pools:
  - dataRaidGroups:
    - blockDevices:
      # /var/openebs/sparse/0-ndm-sparse.img  10GB
      - blockDeviceName: sparse-6b277da87b7487e501c03ea0001d6d92
    nodeSelector:
      kubernetes.io/hostname: shubham
    poolConfig:
      dataRaidGroupType: stripe
```

## Pending items
- [ ] Unit testing
- [x] Implementing `makePools` for other poolTypes
- [ ] Adding capacity restriction for the pools

## Supported poolTypes

- [x] stripe
- [x] mirror
- [ ] raidz
- [ ] raidz2
