### PR TITLE
Update headings for CVRs under CStor vol describe

### DIFF
--- a/pkg/util/constant.go
+++ b/pkg/util/constant.go
@@ -148,8 +148,8 @@ var (
 	// CstorReplicaColumnDefinations stores the Table headers for CVR Details
 	CstorReplicaColumnDefinations = []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string"},
-		{Name: "Total", Type: "string"},
-		{Name: "Used", Type: "string"},
+		{Name: "ZFS Used(compressed)", Type: "string"},
+		{Name: "LogicalReferenced", Type: "string"},
 		{Name: "Status", Type: "string"},
 		{Name: "Age", Type: "string"},
 	}


### PR DESCRIPTION
fixes: #135 

Uses better terms to denote, `Total` and `Free` under _cstor volume describe output_ so that users don't think of it like `Total=Used+Free`(and get confused when Total < Used) outright but rather understand that `cvr.spec.capacity.Total` is `zfs used` and `cvr.spec.capacity.Used` is `zfs logical referenced`, wherein the earlier `total` can include all descendants like snapshots and is the actual zeros and ones written on the disk post compression(including snapshots, maybe clones, etc), where-as the earlier `used` refers to the data which the application(s) have written to the pool(minus the compression).

Co-Authored-by: Mayank Patel (@mynktl) <mayank.patel@mayadata.io>
Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>